### PR TITLE
DOC-12312: streaming completed requests to local files

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -643,7 +643,7 @@ Specify `0` (the default) to disable completed request streaming.
 
 Completed request streaming is available in Couchbase Server 7.6.4 and later.
 
-Refer to [Stream Completed Requests][sys-history] for more information and examples. +
+Refer to link:/server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-history[Stream Completed Requests] for more information and examples. +
 **Default** : `0`|integer (int32)
 |**completed-threshold** +
 __optional__|[#completed-threshold]

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1459,7 +1459,7 @@ definitions:
 
           Refer to [Stream Completed Requests][sys-history] for more information and examples.
 
-          [sys-completed-stream]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-history
+          [sys-history]: /server/7.6/manage/monitor/monitoring-n1ql-query.html#sys-history
       completed-threshold:
         type: integer
         format: int32


### PR DESCRIPTION
Docs ticket: DOC-12312

This PR adds the `completed-stream-size` property to the Query Admin Settings REST API.

Docs preview: [Query Admin REST API › Definitions › Statements › completed-stream-size](https://preview.docs-test.couchbase.com/server/current/n1ql/n1ql-rest-api/admin.html#completed-stream-size)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

This PR must be merged at the same time as the following:

* https://github.com/couchbaselabs/docs-devex/pull/273