### PR TITLE
[DOC-10909] Add 'Errors' Logging Parameter

### DIFF
--- a/docs/modules/n1ql-rest-admin/pages/index.adoc
+++ b/docs/modules/n1ql-rest-admin/pages/index.adoc
@@ -5003,6 +5003,25 @@ If specified, all completed queries with this user name are logged.
 a¦ String
 
 
+a¦ 
+*errors* +
+_optional_
+a¦ 
+
+[markdown]
+--
+The number of errors.
+If specified, all completed queries that return at least this many errors are logged. 
+Queries with fewer errors are not logged.
+
+--
+
+[%hardbreaks]
+*Example:* `5`
+{blank}
+a¦ Integer (int32)
+
+
 |===
 
 //end::Logging_Parameters[]

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1470,6 +1470,16 @@ components:
             description: |
               A user name, as given in the request credentials.
               If specified, all completed queries with this user name are logged.
+          errors: 
+            type: integer
+            format: int32
+            example: 5
+            x-has-example: true
+            description: |
+              The number of errors.
+              If specified, all completed queries that return at least this many errors are logged. 
+              Queries with fewer errors are not logged.
+              
       completed-limit:
         type: integer
         format: int32


### PR DESCRIPTION
Add a new 'errors' logging parameter to Query Admin API. 

Doc Jira: DOC-10909
Doc preview: [Logging Parameters](https://preview.docs-test.couchbase.com/docs-devex-DOC-10909-errors-logging-qualifier/server/current/n1ql-rest-admin/index.html#Logging_Parameters)
Preview credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Linked PR: https://github.com/couchbaselabs/docs-devex/pull/365