### PR TITLE
DOC-9592: Document external datasets on Azure Data Lake

### DIFF
--- a/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
+++ b/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
@@ -1140,10 +1140,7 @@ components:
 
   ResponseAzureDataLake:
     title: Azure Data Lake Response
-    description: |-
-      These properties are returned for Azure Data Lake links.
-
-      (Azure Data Lake links are available in Developer Preview.)
+    description: These properties are returned for Azure Data Lake links.
     allOf:
       - $ref: "#/components/schemas/ResponseAll"
       - $ref: "#/components/schemas/ResponseAzureSpecific"

--- a/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
+++ b/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
@@ -59,6 +59,7 @@ paths:
                 - $ref: "#/components/schemas/LegacyCreateCouchbase"
                 - $ref: "#/components/schemas/LegacyCreateS3"
                 - $ref: "#/components/schemas/LegacyCreateAzureBlob"
+                - $ref: "#/components/schemas/LegacyCreateAzureDataLake"
                 - $ref: "#/components/schemas/LegacyCreateGCS"
               # discriminator:
               #   propertyName: type
@@ -147,6 +148,7 @@ paths:
                 - $ref: "#/components/schemas/LegacyEditCouchbase"
                 - $ref: "#/components/schemas/LegacyEditS3"
                 - $ref: "#/components/schemas/LegacyEditAzureBlob"
+                - $ref: "#/components/schemas/LegacyEditAzureDataLake"
                 - $ref: "#/components/schemas/LegacyEditGCS"
               # discriminator:
               #   propertyName: type
@@ -243,6 +245,7 @@ paths:
                 - $ref: "#/components/schemas/RequestCreateCouchbase"
                 - $ref: "#/components/schemas/RequestCreateS3"
                 - $ref: "#/components/schemas/RequestCreateAzureBlob"
+                - $ref: "#/components/schemas/RequestCreateAzureDataLake"
                 - $ref: "#/components/schemas/RequestCreateGCS"
               # discriminator:
               #   propertyName: type
@@ -311,6 +314,7 @@ paths:
                 - $ref: "#/components/schemas/RequestEditCouchbase"
                 - $ref: "#/components/schemas/RequestEditS3"
                 - $ref: "#/components/schemas/RequestEditAzureBlob"
+                - $ref: "#/components/schemas/RequestEditAzureDataLake"
                 - $ref: "#/components/schemas/RequestEditGCS"
               # discriminator:
               #   propertyName: type
@@ -381,6 +385,7 @@ components:
         - couchbase
         - s3
         - azureblob
+        - azuredatalake
         - gcs
     in: query
     required: false
@@ -410,11 +415,15 @@ components:
       * `couchbase`: A link to a remote Couchbase cluster.
       * `s3`: A link to the Amazon S3 service.
       * `azureblob`: A link to Azure Blob Storage.
+      * `azuredatalake`: A link to Azure Data Lake.
       * `gcs`: A link to Google Cloud Storage.
+
+      (Azure Data Lake links are available in Developer Preview.)
     enum:
       - couchbase
       - s3
       - azureblob
+      - azuredatalake
       - gcs
 
   CommonTypeEdit:
@@ -427,6 +436,7 @@ components:
       - couchbase
       - s3
       - azureblob
+      - azuredatalake
       - gcs
 
   # Workaround for OpenApi Generator. Should have separate parameters for Couchbase and Azure.
@@ -436,19 +446,19 @@ components:
       For Couchbase links, this is the content of the client certificate.
       Required for links with full encryption if using a client key.
 
-      For Azure Blob links, this is the client certificate for the registered application.
+      For Azure Blob and Azure Data Lake links, this is the client certificate for the registered application.
       Used for Azure Active Directory client certificate authentication.
 
       You should URL-encode this parameter to escape any special characters.
 
-  # Workaround for OpenApi Generator. Should have separate parameters for Couchbase and Azure.
+  # Workaround for OpenApi Generator. Should have separate parameters for Azure and Google Cloud.
   CommonEndpoint:
     type: string
     description: |-
-      For Azure Blob links and Google Cloud Storage links.
+      For Azure Blob, Azure Data Lake, and Google Cloud Storage links.
       The endpoint URI.
 
-      Required for Azure Blob links; optional for Google Cloud Storage links.
+      Required for Azure Blob and Azure Data Lake links; optional for Google Cloud Storage links.
 
   RequestCreateAll:
     type: object
@@ -474,7 +484,13 @@ components:
     title: Create Azure Blob Link Request
     allOf:
       - $ref: "#/components/schemas/RequestCreateAll"
-      - $ref: "#/components/schemas/RequestSpecificAzureBlob"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
+
+  RequestCreateAzureDataLake:
+    title: Create Azure Data Lake Link Request
+    allOf:
+      - $ref: "#/components/schemas/RequestCreateAll"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
 
   RequestCreateGCS:
     title: Create GCS Link Request
@@ -504,7 +520,13 @@ components:
     title: Edit Azure Blob Link Request
     allOf:
       - $ref: "#/components/schemas/RequestEditAll"
-      - $ref: "#/components/schemas/RequestSpecificAzureBlob"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
+
+  RequestEditAzureDataLake:
+    title: Edit Azure Data Lake Link Request
+    allOf:
+      - $ref: "#/components/schemas/RequestEditAll"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
 
   RequestEditGCS:
     title: Edit GCS Link Request
@@ -542,7 +564,13 @@ components:
     title: Create Azure Blob Link Request (Legacy)
     allOf:
       - $ref: "#/components/schemas/LegacyCreateAll"
-      - $ref: "#/components/schemas/RequestSpecificAzureBlob"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
+
+  LegacyCreateAzureDataLake:
+    title: Create Azure Data Lake Link Request (Legacy)
+    allOf:
+      - $ref: "#/components/schemas/LegacyCreateAll"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
 
   LegacyCreateGCS:
     title: Create GCS Link Request (Legacy)
@@ -579,7 +607,13 @@ components:
     title: Edit Azure Blob Link Request (Legacy)
     allOf:
       - $ref: "#/components/schemas/LegacyEditAll"
-      - $ref: "#/components/schemas/RequestSpecificAzureBlob"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
+
+  LegacyEditAzureDataLake:
+    title: Edit Azure Data Lake Link Request (Legacy)
+    allOf:
+      - $ref: "#/components/schemas/LegacyEditAll"
+      - $ref: "#/components/schemas/RequestSpecificAzure"
 
   LegacyEditGCS:
     title: Edit GCS Link Request (Legacy)
@@ -705,8 +739,8 @@ components:
           For S3 links only.
           The Amazon S3 service endpoint.
 
-  RequestSpecificAzureBlob:
-    title: Azure Blob Specific Request
+  RequestSpecificAzure:
+    title: Azure Specific Request
     type: object
     # required:
     #   - endpoint
@@ -714,11 +748,11 @@ components:
       endpoint:
         $ref: "#/components/schemas/CommonEndpoint"
         # type: string
-        # description: For Azure Blob links, this is the endpoint URI.
+        # description: For Azure Blob and Azure Data Lake links, this is the endpoint URI.
       accountName:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The account name.
           Used for shared key authentication.
 
@@ -727,7 +761,7 @@ components:
       accountKey:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The account key.
           Used for shared key authentication.
 
@@ -736,7 +770,7 @@ components:
       sharedAccessSignature:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           A token that can be used for authentication.
           Used for shared access signature authentication.
 
@@ -745,7 +779,7 @@ components:
       managedIdentityId:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The managed identity ID.
           Used for managed identity authentication.
           Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.
@@ -755,7 +789,7 @@ components:
       clientId:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The client ID for the registered application.
           Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.
 
@@ -764,7 +798,7 @@ components:
       tenantId:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The tenant ID where the registered application is created.
           Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.
 
@@ -773,7 +807,7 @@ components:
       clientSecret:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The client secret for the registered application.
           Used for Azure Active Directory client secret authentication.
 
@@ -783,7 +817,7 @@ components:
         $ref: "#/components/schemas/CommonClientCertificate"
         # type: string
         # description: >
-        #   For Azure Blob links, this is the client certificate for the registered application.
+        #   For Azure Blob and Azure Data Lake links, this is the client certificate for the registered application.
         #   Used for Azure Active Directory client certificate authentication.
       
       
@@ -791,7 +825,7 @@ components:
       clientCertificatePassword:
         type: string
         description: >
-          For Azure Blob links only.
+          For Azure Blob and Azure Data Lake links.
           The client certificate password for the registered application.
           Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.
 
@@ -834,6 +868,7 @@ components:
         couchbase: "#/components/schemas/ResponseCouchbase"
         s3: "#/components/schemas/ResponseS3"
         azureblob: "#/components/schemas/ResponseAzureBlob"
+        azuredatalake: "#/components/schemas/ResponseAzureDataLake"
         gcs: "#/components/schemas/ResponseGCS"
     required:
       - scope
@@ -863,11 +898,15 @@ components:
           * `couchbase`: A link to a remote Couchbase cluster.
           * `s3`: A link to the Amazon S3 service.
           * `azureblob`: A link to Microsoft Azure Blob Storage.
+          * `azuredatalake`: A link to Microsoft Azure Data Lake.
           * `gcs`: A link to Google Cloud Storage.
+
+          (Azure Data Lake links are available in Developer Preview.)
         enum:
           - couchbase
           - s3
           - azureblob
+          - azuredatalake
           - gcs
 
   ResponseCouchbase:
@@ -1097,10 +1136,21 @@ components:
     description: These properties are returned for Azure Blob links.
     allOf:
       - $ref: "#/components/schemas/ResponseAll"
-      - $ref: "#/components/schemas/ResponseAzureBlobSpecific"
+      - $ref: "#/components/schemas/ResponseAzureSpecific"
 
-  ResponseAzureBlobSpecific:
-        title: Azure Blob Specific Response
+  ResponseAzureDataLake:
+    title: Azure Data Lake Response
+    description: |-
+      These properties are returned for Azure Data Lake links.
+
+      (Azure Data Lake links are available in Developer Preview.)
+    allOf:
+      - $ref: "#/components/schemas/ResponseAll"
+      - $ref: "#/components/schemas/ResponseAzureSpecific"
+
+  ResponseAzureSpecific:
+        title: Azure Specific Response
+        description: Properties specific to Azure Blob and Azure Data Lake links.
         type: object
         required:
           - endpoint

--- a/docs/modules/analytics-rest-links/pages/index.adoc
+++ b/docs/modules/analytics-rest-links/pages/index.adoc
@@ -489,7 +489,7 @@ include::index.adoc[tag=desc-CommonType, opts=optional]
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ 
@@ -589,7 +589,7 @@ a¦
 
 [markdown]
 --
-For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
+For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob and Azure Data Lake links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
 --
 
 [%hardbreaks]
@@ -708,7 +708,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob links; optional for Google Cloud Storage links.
+For Azure Blob, Azure Data Lake, and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob and Azure Data Lake links; optional for Google Cloud Storage links.
 --
 
 [%hardbreaks]
@@ -725,7 +725,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -742,7 +742,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -759,7 +759,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -776,7 +776,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -793,7 +793,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -810,7 +810,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -827,7 +827,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -844,7 +844,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1128,7 +1128,7 @@ include::index.adoc[tag=desc-CommonTypeEdit, opts=optional]
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ 
@@ -1228,7 +1228,7 @@ a¦
 
 [markdown]
 --
-For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
+For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob and Azure Data Lake links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
 --
 
 [%hardbreaks]
@@ -1347,7 +1347,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob links; optional for Google Cloud Storage links.
+For Azure Blob, Azure Data Lake, and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob and Azure Data Lake links; optional for Google Cloud Storage links.
 --
 
 [%hardbreaks]
@@ -1364,7 +1364,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1381,7 +1381,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1398,7 +1398,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1415,7 +1415,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1432,7 +1432,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1449,7 +1449,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1466,7 +1466,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1483,7 +1483,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -1791,7 +1791,7 @@ The type of the link. If this parameter is omitted, all link types are retrieved
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ String
@@ -2029,7 +2029,7 @@ The type of the link. If this parameter is omitted, all link types are retrieved
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ String
@@ -2535,7 +2535,7 @@ include::index.adoc[tag=desc-CommonTypeEdit, opts=optional]
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ 
@@ -2795,7 +2795,7 @@ include::index.adoc[tag=desc-CommonType, opts=optional]
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ 
@@ -2895,7 +2895,7 @@ a¦
 
 [markdown]
 --
-For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
+For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob and Azure Data Lake links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
 --
 
 [%hardbreaks]
@@ -3014,7 +3014,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob links; optional for Google Cloud Storage links.
+For Azure Blob, Azure Data Lake, and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob and Azure Data Lake links; optional for Google Cloud Storage links.
 --
 
 [%hardbreaks]
@@ -3031,7 +3031,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3048,7 +3048,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3065,7 +3065,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3082,7 +3082,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3099,7 +3099,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3116,7 +3116,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3133,7 +3133,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3150,7 +3150,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3445,7 +3445,7 @@ include::index.adoc[tag=desc-CommonTypeEdit, opts=optional]
 --
 
 [%hardbreaks]
-*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;gcs&quot;`
+*Values:* `&quot;couchbase&quot;`, `&quot;s3&quot;`, `&quot;azureblob&quot;`, `&quot;azuredatalake&quot;`, `&quot;gcs&quot;`
 {blank}
 
 a¦ 
@@ -3545,7 +3545,7 @@ a¦
 
 [markdown]
 --
-For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
+For Couchbase links, this is the content of the client certificate. Required for links with full encryption if using a client key.  For Azure Blob and Azure Data Lake links, this is the client certificate for the registered application. Used for Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters.
 --
 
 [%hardbreaks]
@@ -3664,7 +3664,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob links; optional for Google Cloud Storage links.
+For Azure Blob, Azure Data Lake, and Google Cloud Storage links. The endpoint URI.  Required for Azure Blob and Azure Data Lake links; optional for Google Cloud Storage links.
 --
 
 [%hardbreaks]
@@ -3681,7 +3681,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account name. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3698,7 +3698,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The account key. Used for shared key authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3715,7 +3715,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. A token that can be used for authentication. Used for shared access signature authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3732,7 +3732,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The managed identity ID. Used for managed identity authentication. Only available if the application is running on an Azure instance, e.g. an Azure virtual machine.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3749,7 +3749,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client ID for the registered application. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3766,7 +3766,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The tenant ID where the registered application is created. Used for Azure Active Directory client secret authentication, or Azure Active Directory client certificate authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3783,7 +3783,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client secret for the registered application. Used for Azure Active Directory client secret authentication.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3800,7 +3800,7 @@ a¦
 
 [markdown]
 --
-For Azure Blob links only. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
+For Azure Blob and Azure Data Lake links. The client certificate password for the registered application. Used for Azure Active Directory client certificate authentication, if the client certificate is password-protected.  You should URL-encode this parameter to escape any special characters. 
 --
 
 [%hardbreaks]
@@ -3980,7 +3980,7 @@ endif::[]
 [#models]
 = Definitions
 
-:count-models: 14
+:count-models: 15
 
 :leveloffset: +1
 
@@ -4002,7 +4002,8 @@ xref:CommonTypeEdit[]
 endif::enum-definitions[]
 xref:ResponseAll[]
 xref:ResponseAzureBlob[]
-xref:ResponseAzureBlobSpecific[]
+xref:ResponseAzureDataLake[]
+xref:ResponseAzureSpecific[]
 xref:ResponseCouchbase[]
 xref:ResponseCouchbaseSpecific[]
 xref:ResponseCouchbaseSpecificNode[]
@@ -4027,7 +4028,10 @@ The type of the link.
 * `couchbase`: A link to a remote Couchbase cluster.
 * `s3`: A link to the Amazon S3 service.
 * `azureblob`: A link to Azure Blob Storage.
+* `azuredatalake`: A link to Azure Data Lake.
 * `gcs`: A link to Google Cloud Storage.
+
+(Azure Data Lake links are available in Developer Preview.)
 //end::desc-CommonType[]
 
 .Schema
@@ -4134,11 +4138,14 @@ The type of the link.
 * `couchbase`: A link to a remote Couchbase cluster.
 * `s3`: A link to the Amazon S3 service.
 * `azureblob`: A link to Microsoft Azure Blob Storage.
+* `azuredatalake`: A link to Microsoft Azure Data Lake.
 * `gcs`: A link to Google Cloud Storage.
+
+(Azure Data Lake links are available in Developer Preview.)
 --
 
 [%hardbreaks]
-*Values:* `"couchbase"`, `"s3"`, `"azureblob"`, `"gcs"`
+*Values:* `"couchbase"`, `"s3"`, `"azureblob"`, `"azuredatalake"`, `"gcs"`
 {blank}
 a¦ String
 
@@ -4156,6 +4163,12 @@ This schema has alternative properties, depending on the value of *type*:
 a| `azureblob`
 a| These properties are returned for Azure Blob links.
 a| xref:ResponseAzureBlob[]
+
+a| `azuredatalake`
+a| These properties are returned for Azure Data Lake links.
+
+(Azure Data Lake links are available in Developer Preview.)
+a| xref:ResponseAzureDataLake[]
 
 a| `couchbase`
 a| These properties are returned for remote Couchbase links.
@@ -4204,7 +4217,7 @@ All of the following:
 * xref:ResponseAll[]
 
 
-* xref:ResponseAzureBlobSpecific[]
+* xref:ResponseAzureSpecific[]
 
 
 
@@ -4219,25 +4232,67 @@ All of the following:
 
 
 
-// markup not found, no include::{specDir}definitions/ResponseAzureBlobSpecific/definition-before.adoc[opts=optional]
+// markup not found, no include::{specDir}definitions/ResponseAzureDataLake/definition-before.adoc[opts=optional]
 
 
 ifdef::collapse-models[]
 [discrete]
 endif::collapse-models[]
-[#ResponseAzureBlobSpecific]
-= Azure Blob Specific Response
+[#ResponseAzureDataLake]
+= Azure Data Lake Response
 
 :leveloffset: +1
 
-// markup not found, no include::{specDir}definitions/ResponseAzureBlobSpecific/definition-begin.adoc[opts=optional]
+// markup not found, no include::{specDir}definitions/ResponseAzureDataLake/definition-begin.adoc[opts=optional]
+
+
+.icon:bars[fw] Composite Schema
+{blank}
+
+All of the following:
+
+* xref:ResponseAll[]
+
+
+* xref:ResponseAzureSpecific[]
+
+
+
+
+// markup not found, no include::{specDir}definitions/ResponseAzureDataLake/definition-end.adoc[opts=optional]
+
+
+:leveloffset: -1
+
+// markup not found, no include::{specDir}definitions/ResponseAzureDataLake/definition-after.adoc[opts=optional]
+
+
+
+
+// markup not found, no include::{specDir}definitions/ResponseAzureSpecific/definition-before.adoc[opts=optional]
+
+
+ifdef::collapse-models[]
+[discrete]
+endif::collapse-models[]
+[#ResponseAzureSpecific]
+= Azure Specific Response
+
+:leveloffset: +1
+
+// markup not found, no include::{specDir}definitions/ResponseAzureSpecific/definition-begin.adoc[opts=optional]
 
 
 .icon:brackets-curly[fw] Object
 {blank}
 
-//tag::ResponseAzureBlobSpecific[]
+//tag::ResponseAzureSpecific[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponseAzureSpecific[]
+Properties specific to Azure Blob and Azure Data Lake links.
+//end::desc-ResponseAzureSpecific[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -4414,17 +4469,17 @@ a¦ String
 
 |===
 
-//end::ResponseAzureBlobSpecific[]
+//end::ResponseAzureSpecific[]
 
 
 
 
-// markup not found, no include::{specDir}definitions/ResponseAzureBlobSpecific/definition-end.adoc[opts=optional]
+// markup not found, no include::{specDir}definitions/ResponseAzureSpecific/definition-end.adoc[opts=optional]
 
 
 :leveloffset: -1
 
-// markup not found, no include::{specDir}definitions/ResponseAzureBlobSpecific/definition-after.adoc[opts=optional]
+// markup not found, no include::{specDir}definitions/ResponseAzureSpecific/definition-after.adoc[opts=optional]
 
 
 

--- a/docs/modules/analytics-rest-links/pages/index.adoc
+++ b/docs/modules/analytics-rest-links/pages/index.adoc
@@ -4166,8 +4166,6 @@ a| xref:ResponseAzureBlob[]
 
 a| `azuredatalake`
 a| These properties are returned for Azure Data Lake links.
-
-(Azure Data Lake links are available in Developer Preview.)
 a| xref:ResponseAzureDataLake[]
 
 a| `couchbase`

--- a/docs/preview/DOC-9592.yml
+++ b/docs/preview/DOC-9592.yml
@@ -1,0 +1,7 @@
+sources:
+  docs-server:
+    branches: release/8.0
+  docs-analytics:
+    branches: DOC-9592
+  docs-devex:
+    branches: release/8.0


### PR DESCRIPTION
Docs issue: DOC-9592

Adds documentation for external datasets on Azure Data Lake. I've assumed that Azure Data Lake is available in Developer Preview and that it has the same parameters as Azure Blob Storage.

Docs preview: [Analytics Links REST API](https://preview.docs-test.couchbase.com/cb-swagger-DOC-9592/server/current/analytics-rest-links/index.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

Must be merged at the same time as the following PR:

* https://github.com/couchbase/docs-analytics/pull/48