### PR TITLE
DOC-13542: Port from Capella to Morpheus

### DIFF
--- a/docs/modules/n1ql-rest-admin/pages/index.adoc
+++ b/docs/modules/n1ql-rest-admin/pages/index.adoc
@@ -4988,9 +4988,11 @@ endif::alt-markdown-links[]
 The opaque ID or context provided by the client.
 If specified, all completed requests with this client context ID are logged.
 
+// tag::desc-more[]
 Refer to the [request-level][client_context_id] `client_context_id` parameter for more information.
 
 [client_context_id]: ../n1ql-rest-query/index.html#client_context_id
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -5718,9 +5720,11 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 The opaque ID or context provided by the client.
 
+// tag::desc-more[]
 Refer to the [request-level][client_context_id] `client_context_id` parameter for more information.
 
 [client_context_id]: ../n1ql-rest-query/index.html#client_context_id
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6202,10 +6206,12 @@ If any part of the path contains a special character, that part of the path must
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [request-level][atrcollection_req] `atrcollection` parameter specifies this property per request.
 If a request does not include this parameter, the node-level `atrcollection` setting will be used.
 
 [atrcollection_req]: ../n1ql-rest-query/index.html#atrcollection_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6249,10 +6255,12 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
 
+// tag::desc-more[]
 The [cluster-level][queryCleanupClientAttempts] `queryCleanupClientAttempts` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryCleanupClientAttempts]: ../n1ql-rest-settings/index.html#queryCleanupClientAttempts
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6275,10 +6283,12 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
 
+// tag::desc-more[]
 The [cluster-level][queryCleanupLostAttempts] `queryCleanupLostAttempts` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryCleanupLostAttempts]: ../n1ql-rest-settings/index.html#queryCleanupLostAttempts
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6315,10 +6325,12 @@ Valid units are:
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [cluster-level][queryCleanupWindow] `queryCleanupWindow` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryCleanupWindow]: ../n1ql-rest-settings/index.html#queryCleanupWindow
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6363,10 +6375,12 @@ Refer to [Configure Completed Requests][sys-completed-config] for more informati
 
 [sys-completed-config]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config
 
+// tag::desc-more[]
 The [cluster-level][queryCompletedLimit] `queryCompletedLimit` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryCompletedLimit]: ../n1ql-rest-settings/index.html#queryCompletedLimit
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6397,10 +6411,12 @@ Refer to [Configure Completed Requests][sys-completed-config] for more informati
 
 [sys-completed-config]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config
 
+// tag::desc-more[]
 The [cluster-level][queryCompletedMaxPlanSize] `queryCompletedMaxPlanSize` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryCompletedMaxPlanSize]: ../n1ql-rest-settings/index.html#queryCompletedMaxPlanSize
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6456,10 +6472,12 @@ Refer to [Configure Completed Requests][sys-completed-config] for more informati
 
 [sys-completed-config]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config
 
+// tag::desc-more[]
 The [cluster-level][queryCompletedThreshold] `queryCompletedThreshold` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryCompletedThreshold]: ../n1ql-rest-settings/index.html#queryCompletedThreshold
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6486,10 +6504,12 @@ When set to `true`, the query response document includes a controls section with
 
 NOTE: If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
+// tag::desc-more[]
 The [request-level][controls_req] `controls` parameter specifies this property per request.
 If a request does not include this parameter, the node-level `controls` setting will be used.
 
 [controls_req]: ../n1ql-rest-query/index.html#controls_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6628,10 +6648,12 @@ Major items, like crashes.
 
 * `NONE` &mdash; Doesn't write anything.
 
+// tag::desc-more[]
 The [cluster-level][queryLogLevel] `queryLogLevel` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryLogLevel]: ../n1ql-rest-settings/index.html#queryLogLevel
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6682,6 +6704,7 @@ Refer to [Max Parallelism][max-parallelism] for more information.
 
 [max-parallelism]: ../n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism
 
+// tag::desc-more[]
 The [cluster-level][queryMaxParallelism] `queryMaxParallelism` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -6692,6 +6715,7 @@ NOTE: To enable queries to run in parallel, you must specify the cluster-level `
 
 [queryMaxParallelism]: ../n1ql-rest-settings/index.html#queryMaxParallelism
 [max_parallelism_req]: ../n1ql-rest-query/index.html#max_parallelism_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6724,6 +6748,7 @@ It does not take into account any other memory that might be used to process a r
 Within a transaction, this setting enforces the memory quota for the transaction by tracking the
 delta table and the transaction log (approximately).
 
+// tag::desc-more[]
 The [cluster-level][queryMemoryQuota] `queryMemoryQuota` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -6732,6 +6757,7 @@ If a request includes this parameter, it will be capped by the node-level `memor
 
 [queryMemoryQuota]: ../n1ql-rest-settings/index.html#queryMemoryQuota
 [memory_quota_req]: ../n1ql-rest-query/index.html#memory_quota_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6794,10 +6820,12 @@ SQL++ feature control.
 This setting is provided for technical support only.
 The value may be an integer, or a string representing a hexadecimal number.
 
+// tag::desc-more[]
 The [cluster-level][queryN1QLFeatCtrl] `queryN1QLFeatCtrl` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryN1QLFeatCtrl]: ../n1ql-rest-settings/index.html#queryN1QLFeatCtrl
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6831,10 +6859,12 @@ To do this, the Query service calculates the difference between the total system
 
 - If the difference is 8 GiB or less, the default soft memory limit is set to 90% of the total system RAM.
 
+// tag::desc-more[]
 The [cluster-level][queryNodeQuota] `queryNodeQuota` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryNodeQuota]: ../n1ql-rest-settings/index.html#queryNodeQuota
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6857,10 +6887,12 @@ endif::alt-markdown-links[]
 The percentage of the `node-quota` that is dedicated to tracked value content memory across all active requests on this node.
 (The `memory-quota` setting specifies the maximum amount of document memory an individual request may use on this node.)
 
+// tag::desc-more[]
 The [cluster-level][queryNodeQuotaValPercent] `queryNodeQuotaValPercent` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryNodeQuotaValPercent]: ../n1ql-rest-settings/index.html#queryNodeQuotaValPercent
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6891,10 +6923,12 @@ The number of CPUs can never be greater than the number of logical CPUs.
 In Community Edition, the number of allowed CPUs cannot be greater than 4.
 In Enterprise Edition, there is no limit to the number of allowed CPUs.
 
+// tag::desc-more[]
 The [cluster-level][queryNumCpus] `queryNumCpus` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryNumCpus]: ../n1ql-rest-settings/index.html#queryNumCpus
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6919,6 +6953,7 @@ Specifies the total number of [active transaction records][additional-storage-us
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [cluster-level][queryNumAtrs] `queryNumAtrs` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -6927,6 +6962,7 @@ The minimum of that and the node-level `numatrs` setting is applied.
 
 [queryNumAtrs]: ../n1ql-rest-settings/index.html#queryNumAtrs
 [numatrs_req]: ../n1ql-rest-query/index.html#numatrs_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6948,6 +6984,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Controls the number of items execution operators can batch for Fetch from the KV.
 
+// tag::desc-more[]
 The [cluster-level][queryPipelineBatch] `queryPipelineBatch` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -6956,6 +6993,7 @@ The minimum of that and the node-level `pipeline-batch` setting is applied.
 
 [queryPipelineBatch]: ../n1ql-rest-settings/index.html#queryPipelineBatch
 [pipeline_batch_req]: ../n1ql-rest-query/index.html#pipeline_batch_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -6979,6 +7017,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Maximum number of items each execution operator can buffer between various operators.
 
+// tag::desc-more[]
 The [cluster-level][queryPipelineCap] `queryPipelineCap` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -6987,6 +7026,7 @@ The minimum of that and the node-level `pipeline-cap` setting is applied.
 
 [queryPipelineCap]: ../n1ql-rest-settings/index.html#queryPipelineCap
 [pipeline_cap_req]: ../n1ql-rest-query/index.html#pipeline_cap_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7027,10 +7067,12 @@ endif::alt-markdown-links[]
 Maximum number of prepared statements in the cache.
 When this cache reaches the limit, the least recently used prepared statements will be discarded as new prepared statements are created.
 
+// tag::desc-more[]
 The [cluster-level][queryPreparedLimit] `queryPreparedLimit` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [queryPreparedLimit]: ../n1ql-rest-settings/index.html#queryPreparedLimit
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7053,10 +7095,12 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Specifies whether query results are returned in pretty format.
 
+// tag::desc-more[]
 The [request-level][pretty_req] `pretty` parameter specifies this property per request.
 If a request does not include this parameter, the node-level setting is used, which defaults to `false`.
 
 [pretty_req]: ../n1ql-rest-query/index.html#pretty_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7094,10 +7138,12 @@ Refer to [Monitoring and Profiling Details][monitor-profile-details] for more in
 
 [monitor-profile-details]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#monitor-profile-details
 
+// tag::desc-more[]
 The [request-level][profile_req] `profile` parameter specifies this property per request.
 If a request does not include this parameter, the node-level `profile` setting will be used.
 
 [profile_req]: ../n1ql-rest-query/index.html#profile_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7143,6 +7189,7 @@ This parameter controls when to use scan backfill.
 Use `0` or a negative number to disable.
 Smaller values reduce GC, while larger values reduce indexer backfill.
 
+// tag::desc-more[]
 The [cluster-level][queryScanCap] `queryScanCap` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -7151,6 +7198,7 @@ The minimum of that and the node-level `scan-cap` setting is applied.
 
 [queryScanCap]: ../n1ql-rest-settings/index.html#queryScanCap
 [scan_cap_req]: ../n1ql-rest-query/index.html#scan_cap_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7198,6 +7246,7 @@ It must not be delimited by quotes, and must not include a unit.
 Specify `0` (the default value) or a negative integer to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
+// tag::desc-more[]
 The [cluster-level][queryTimeout] `queryTimeout` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -7206,6 +7255,7 @@ The minimum of that and the node-level `timeout` setting is applied.
 
 [queryTimeout]: ../n1ql-rest-settings/index.html#queryTimeout
 [timeout_req]: ../n1ql-rest-query/index.html#timeout_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7240,6 +7290,7 @@ When disabled, no timeout is applied and the transaction runs for however long i
 
 [tximplicit]: ../n1ql-rest-query/index.html#tximplicit
 
+// tag::desc-more[]
 The [cluster-level][queryTxTimeout] `queryTxTimeout` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -7248,6 +7299,7 @@ The minimum of that and the node-level `txtimeout` setting is applied.
 
 [queryTxTimeout]: ../n1ql-rest-settings/index.html#queryTxTimeout
 [txtimeout_req]: ../n1ql-rest-query/index.html#txtimeout_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7271,6 +7323,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Specifies whether the cost-based optimizer is enabled.
 
+// tag::desc-more[]
 The [cluster-level][queryUseCBO] `queryUseCBO` setting specifies this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -7279,6 +7332,7 @@ If a request does not include this parameter, the node-level setting is used, wh
 
 [queryUseCBO]: ../n1ql-rest-settings/index.html#queryUseCBO
 [use_cbo_req]: ../n1ql-rest-query/index.html#use_cbo_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -7317,6 +7371,7 @@ Reading from replica is only possible if the cluster uses Couchbase Server 7.6.0
 Note that KV range scans cannot currently be started on a replica vBucket.
 If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
+// tag::desc-more[]
 The [cluster-level][queryUseReplica] `queryUseReplica` setting specifies the default for this property for the whole cluster.
 When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
 
@@ -7326,6 +7381,7 @@ If the request-level parameter and the node-level setting are both `unset`, read
 
 [queryUseReplica]: ../n1ql-rest-settings/index.html#queryUseReplica
 [use_replica_req]: ../n1ql-rest-query/index.html#use_replica_req
+// end::desc-more[]
 --
 
 [%hardbreaks]

--- a/docs/modules/n1ql-rest-query/pages/index.adoc
+++ b/docs/modules/n1ql-rest-query/pages/index.adoc
@@ -1626,10 +1626,12 @@ If any part of the path contains a special character, that part of the path must
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [node-level][atrcollection-srv] `atrcollection` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
 [atrcollection-srv]: ../n1ql-rest-admin/index.html#atrcollection-srv
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1716,10 +1718,12 @@ When set to `true`, the query response document includes a controls section with
 
 If the request qualifies for caching, these values will also be cached in the `completed_requests` system keyspace.
 
+// tag::desc-more[]
 The [node-level][controls-srv] `controls` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
 [controls-srv]: ../n1ql-rest-admin/index.html#controls-srv
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1882,6 +1886,7 @@ Specifies the maximum parallelism for the query.
 
 The default value is the same as the number of partitions of the index selected for the query.
 
+// tag::desc-more[]
 The [node-level][max-parallelism-srv] `max-parallelism` setting specifies the ceiling for this parameter for a single node.
 If the request-level parameter is zero or negative, the parallelism for the query is set to the node-level setting.
 If the request-level parameter is greater than zero and less than the node-level setting, the request-level parameter overrides the node-level setting.
@@ -1894,6 +1899,7 @@ To enable queries to run in parallel, you must specify the cluster-level `queryM
 
 [max-parallelism-srv]: ../n1ql-rest-admin/index.html#max-parallelism-srv
 [queryMaxParallelism]: ../n1ql-rest-settings/index.html#queryMaxParallelism
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1925,6 +1931,7 @@ It does not take into account any other memory that might be used to process a r
 Within a transaction, this setting enforces the memory quota for the transaction by tracking the
 delta table and the transaction log (approximately).
 
+// tag::desc-more[]
 The [node-level][memory-quota-srv] `memory-quota` setting specifies the ceiling for this parameter for a single node.
 If the node-level setting is zero (the default), the request-level parameter overrides the node-level setting.
 If the node-level setting is greater than zero, the request-level parameter is capped by the node-level setting.
@@ -1934,6 +1941,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [memory-quota-srv]: ../n1ql-rest-admin/index.html#memory-quota-srv
 [queryMemoryQuota]: ../n1ql-rest-settings/index.html#queryMemoryQuota
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2139,6 +2147,7 @@ Must be a positive integer.
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [node-level][numatrs-srv] `numatrs` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
@@ -2147,6 +2156,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [numatrs-srv]: ../n1ql-rest-admin/index.html#numatrs-srv
 [queryNumAtrs]: ../n1ql-rest-settings/index.html#queryNumAtrs
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2170,6 +2180,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Controls the number of items execution operators can batch for Fetch from the KV.
 
+// tag::desc-more[]
 The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
@@ -2178,6 +2189,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [pipeline-batch-srv]: ../n1ql-rest-admin/index.html#pipeline-batch-srv
 [queryPipelineBatch]: ../n1ql-rest-settings/index.html#queryPipelineBatch
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2200,6 +2212,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Maximum number of items each execution operator can buffer between various operators.
 
+// tag::desc-more[]
 The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
@@ -2208,6 +2221,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [pipeline-cap-srv]: ../n1ql-rest-admin/index.html#pipeline-cap-srv
 [queryPipelineCap]: ../n1ql-rest-settings/index.html#queryPipelineCap
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2276,10 +2290,12 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Specifies the query results returned in pretty format.
 
+// tag::desc-more[]
 The [node-level][pretty-srv] `pretty` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
 [pretty-srv]: ../n1ql-rest-admin/index.html#pretty-srv
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2314,10 +2330,12 @@ This information will be included in the `system:active_requests` and `system:co
 
 If `profile` is not set as one of the above values, then the profile setting does not change.
 
+// tag::desc-more[]
 The [node-level][profile-srv] `profile` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
 [profile-srv]: ../n1ql-rest-admin/index.html#profile-srv
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2394,6 +2412,7 @@ This parameter controls when to use scan backfill.
 Use `0` or a negative number to disable.
 Smaller values reduce GC, while larger values reduce indexer backfill.
 
+// tag::desc-more[]
 The [node-level][scan-cap-srv] `scan-cap` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting, but only if it is lower than the node-level setting.
 
@@ -2402,6 +2421,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [scan-cap-srv]: ../n1ql-rest-admin/index.html#scan-cap-srv
 [queryScanCap]: ../n1ql-rest-settings/index.html#queryScanCap
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2640,6 +2660,7 @@ When disabled, no timeout is applied and the request runs for however long it ta
 If `tximplicit` or `txid` is set, this parameter is ignored.
 The request inherits the remaining time of the transaction as timeout.
 
+// tag::desc-more[]
 The [node-level][timeout-srv] `timeout` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 However, if the node-level setting is greater than 0, the timeout for the query is limited to the node-level setting.
@@ -2649,6 +2670,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [timeout-srv]: ../n1ql-rest-admin/index.html#timeout-srv
 [queryTimeout]: ../n1ql-rest-settings/index.html#queryTimeout
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2773,6 +2795,7 @@ When disabled, the request-level timeout is set to the default.
 
 The default is `"15s"` for cbq files or scripts, `"2m"` for interactive cbq sessions or redirected input.
 
+// tag::desc-more[]
 The [node-level][txtimeout-srv] `txtimeout` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 However, if the node-level setting is greater than 0, the transaction timeout for the query is limited to the node-level setting.
@@ -2782,6 +2805,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [txtimeout-srv]: ../n1ql-rest-admin/index.html#txtimeout-srv
 [queryTxTimeout]: ../n1ql-rest-settings/index.html#queryTxTimeout
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2804,6 +2828,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Specifies whether the cost-based optimizer is enabled.
 
+// tag::desc-more[]
 The [node-level][use-cbo-srv] `use-cbo` setting specifies the default for this parameter for a single node.
 The request-level parameter overrides the node-level setting.
 
@@ -2812,6 +2837,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [use-cbo-srv]: ../n1ql-rest-admin/index.html#use-cbo-srv
 [queryUseCBO]: ../n1ql-rest-settings/index.html#queryUseCBO
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -2877,6 +2903,7 @@ Reading from replica is only possible if the cluster uses Couchbase Server 7.6.0
 Note that KV range scans cannot currently be started on a replica vBucket.
 If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
+// tag::desc-more[]
 The [node-level][use-replica-srv] `use-replica` setting specifies the default for this property for a single node.
 The request-level parameter usually overrides the node-level setting.
 However, when the node-level setting is `off`, the request-level parameter cannot enable the property.
@@ -2886,6 +2913,7 @@ When you change the cluster-level setting, the node-level setting is overwritten
 
 [use-replica-srv]: ../n1ql-rest-admin/index.html#use-replica-srv
 [queryUseReplica]: ../n1ql-rest-settings/index.html#queryUseReplica
+// end::desc-more[]
 --
 
 [%hardbreaks]

--- a/docs/modules/n1ql-rest-settings/pages/index.adoc
+++ b/docs/modules/n1ql-rest-settings/pages/index.adoc
@@ -1025,10 +1025,12 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 When enabled, the Query service preferentially aims to clean up just transactions that it has created, leaving transactions for the distributed cleanup process only when it is forced to.
 
+// tag::desc-more[]
 The [node-level][cleanupclientattempts] `cleanupclientattempts` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [cleanupclientattempts]: ../n1ql-rest-admin/index.html#cleanupclientattempts
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1051,10 +1053,12 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 When enabled, the Query service takes part in the distributed cleanup process, and cleans up expired transactions created by any client.
 
+// tag::desc-more[]
 The [node-level][cleanuplostattempts] `cleanuplostattempts` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [cleanuplostattempts]: ../n1ql-rest-admin/index.html#cleanuplostattempts
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1091,10 +1095,12 @@ Valid units are:
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [node-level][cleanupwindow] `cleanupwindow` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [cleanupwindow]: ../n1ql-rest-admin/index.html#cleanupwindow
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1124,10 +1130,12 @@ Refer to [Configure the Completed Requests][sys-completed-config] for more infor
 
 [sys-completed-config]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config
 
+// tag::desc-more[]
 The [node-level][completed-limit] `completed-limit` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [completed-limit]: ../n1ql-rest-admin/index.html#completed-limit
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1158,10 +1166,12 @@ Refer to [Configure the Completed Requests][sys-completed-config] for more infor
 
 [sys-completed-config]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config
 
+// tag::desc-more[]
 The [node-level][completed-max-plan-size] `completed-max-plan-size` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [completed-max-plan-size]: ../n1ql-rest-admin/index.html#completed-max-plan-size
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1193,10 +1203,12 @@ Refer to [Configure the Completed Requests][sys-completed-config] for more infor
 
 [sys-completed-config]: ../n1ql/n1ql-manage/monitoring-n1ql-query.html#sys-completed-config
 
+// tag::desc-more[]
 The [node-level][completed-threshold] `completed-threshold` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [completed-threshold]: ../n1ql-rest-admin/index.html#completed-threshold
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1241,10 +1253,12 @@ Major items, like crashes.
 
 * `NONE` &mdash; Doesn't write anything.
 
+// tag::desc-more[]
 The [node-level][loglevel] `loglevel` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [loglevel]: ../n1ql-rest-admin/index.html#loglevel
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1280,6 +1294,7 @@ Refer to [Max Parallelism][max-parallelism] for more information.
 
 [max-parallelism]: ../n1ql/n1ql-language-reference/index-partitioning.html#max-parallelism
 
+// tag::desc-more[]
 The [node-level][max-parallelism-srv] `max-parallelism` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1290,6 +1305,7 @@ NOTE: To enable queries to run in parallel, you must specify the cluster-level `
 
 [max-parallelism-srv]: ../n1ql-rest-admin/index.html#max-parallelism-srv
 [max_parallelism_req]: ../n1ql-rest-query/index.html#max_parallelism_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1319,6 +1335,7 @@ It does not take into account any other memory that might be used to process a r
 Within a transaction, this setting enforces the memory quota for the transaction by tracking the
 delta table and the transaction log (approximately).
 
+// tag::desc-more[]
 The [node-level][memory-quota-srv] `memory-quota` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1327,6 +1344,7 @@ If a request includes this parameter, it will be capped by the node-level `memor
 
 [memory-quota-srv]: ../n1ql-rest-admin/index.html#memory-quota-srv
 [memory_quota_req]: ../n1ql-rest-query/index.html#memory_quota_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1350,10 +1368,12 @@ endif::alt-markdown-links[]
 SQL++ feature control.
 This setting is provided for technical support only.
 
+// tag::desc-more[]
 The [node-level][n1ql-feat-ctrl] `n1ql-feat-ctrl` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [n1ql-feat-ctrl]: ../n1ql-rest-admin/index.html#n1ql-feat-ctrl
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1385,10 +1405,12 @@ To do this, the Query service calculates the difference between the total system
 
 - If the difference is 8 GiB or less, the default soft memory limit is set to 90% of the total system RAM.
 
+// tag::desc-more[]
 The [node-level][node-quota] `node-quota` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [node-quota]: ../n1ql-rest-admin/index.html#node-quota
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1411,10 +1433,12 @@ endif::alt-markdown-links[]
 The percentage of the `queryNodeQuota` that is dedicated to tracked value content memory across all active requests for every Query node in the cluster.
 (The `queryMemoryQuota` setting specifies the maximum amount of document memory an individual request may use on any Query node in the cluster.)
 
+// tag::desc-more[]
 The [node-level][node-quota-val-percent] `node-quota-val-percent` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [node-quota-val-percent]: ../n1ql-rest-admin/index.html#node-quota-val-percent
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1441,6 +1465,7 @@ Specifies the total number of [active transaction records][additional-storage-us
 
 [additional-storage-use]: /server/8.0/learn/data/transactions.html#active-transaction-record-entries
 
+// tag::desc-more[]
 The [node-level][numatrs-srv] `numatrs` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1449,6 +1474,7 @@ If a request includes this parameter, it will be capped by the node-level `numat
 
 [numatrs-srv]: ../n1ql-rest-admin/index.html#numatrs-srv
 [numatrs_req]: ../n1ql-rest-query/index.html#numatrs_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1479,10 +1505,12 @@ The number of CPUs can never be greater than the number of logical CPUs.
 In Community Edition, the number of allowed CPUs cannot be greater than 4.
 In Enterprise Edition, there is no limit to the number of allowed CPUs.
 
+// tag::desc-more[]
 The [node-level][num-cpus] `num-cpus` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [num-cpus]: ../n1ql-rest-admin/index.html#num-cpus
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1505,6 +1533,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Controls the number of items execution operators can batch for Fetch from the KV.
 
+// tag::desc-more[]
 The [node-level][pipeline-batch-srv] `pipeline-batch` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1513,6 +1542,7 @@ The minimum of that and the node-level `pipeline-batch` setting is applied.
 
 [pipeline-batch-srv]: ../n1ql-rest-admin/index.html#pipeline-batch-srv
 [pipeline_batch_req]: ../n1ql-rest-query/index.html#pipeline_batch_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1536,6 +1566,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Maximum number of items each execution operator can buffer between various operators.
 
+// tag::desc-more[]
 The [node-level][pipeline-cap-srv] `pipeline-cap` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1544,6 +1575,7 @@ The minimum of that and the node-level `pipeline-cap` setting is applied.
 
 [pipeline-cap-srv]: ../n1ql-rest-admin/index.html#pipeline-cap-srv
 [pipeline_cap_req]: ../n1ql-rest-query/index.html#pipeline_cap_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1567,10 +1599,12 @@ endif::alt-markdown-links[]
 Maximum number of prepared statements in the cache.
 When this cache reaches the limit, the least recently used prepared statements will be discarded as new prepared statements are created.
 
+// tag::desc-more[]
 The [node-level][prepared-limit] `prepared-limit` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
 [prepared-limit]: ../n1ql-rest-admin/index.html#prepared-limit
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1598,6 +1632,7 @@ This parameter controls when to use scan backfill.
 Use `0` or a negative number to disable.
 Smaller values reduce GC, while larger values reduce indexer backfill.
 
+// tag::desc-more[]
 The [node-level][scan-cap-srv] `scan-cap` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1606,6 +1641,7 @@ The minimum of that and the node-level `scan-cap` setting is applied.
 
 [scan-cap-srv]: ../n1ql-rest-admin/index.html#scan-cap-srv
 [scan_cap_req]: ../n1ql-rest-query/index.html#scan_cap_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1635,6 +1671,7 @@ It must not be delimited by quotes, and must not include a unit.
 Specify `0` (the default value) or a negative integer to disable.
 When disabled, no timeout is applied and the request runs for however long it takes.
 
+// tag::desc-more[]
 The [node-level][timeout-srv] `timeout` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1643,6 +1680,7 @@ The minimum of that and the node-level `timeout` setting is applied.
 
 [timeout-srv]: ../n1ql-rest-admin/index.html#timeout-srv
 [timeout_req]: ../n1ql-rest-query/index.html#timeout_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1685,6 +1723,7 @@ When disabled, no timeout is applied and the transaction runs for however long i
 
 [tximplicit]: ../n1ql-rest-query/index.html#tximplicit
 
+// tag::desc-more[]
 The [node-level][txtimeout-srv] `txtimeout` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1693,6 +1732,7 @@ If a request includes this parameter, it will be capped by the node-level `txtim
 
 [txtimeout-srv]: ../n1ql-rest-admin/index.html#txtimeout-srv
 [txtimeout_req]: ../n1ql-rest-query/index.html#txtimeout_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1760,6 +1800,7 @@ ifdef::alt-markdown-links[]
 endif::alt-markdown-links[]
 Specifies whether the cost-based optimizer is enabled.
 
+// tag::desc-more[]
 The [node-level][use-cbo-srv] `use-cbo` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1768,6 +1809,7 @@ If a request does not include this parameter, the node-level setting is used, wh
 
 [use-cbo-srv]: ../n1ql-rest-admin/index.html#use-cbo-srv
 [use_cbo_req]: ../n1ql-rest-query/index.html#use_cbo_req
+// end::desc-more[]
 --
 
 [%hardbreaks]
@@ -1806,6 +1848,7 @@ Reading from replica is only possible if the cluster uses Couchbase Server 7.6.0
 Note that KV range scans cannot currently be started on a replica vBucket.
 If a query uses sequential scan and a data node becomes unavailable, the query might return an error, even if read from replica is enabled for the request.
 
+// tag::desc-more[]
 The [node-level][use-replica-srv] `use-replica` setting specifies this property for a single node.
 When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
 
@@ -1815,6 +1858,7 @@ If the request-level parameter and the node-level setting are both `unset`, read
 
 [use-replica-srv]: ../n1ql-rest-admin/index.html#use-replica-srv
 [use_replica_req]: ../n1ql-rest-query/index.html#use_replica_req
+// end::desc-more[]
 --
 
 [%hardbreaks]

--- a/templates/property.mustache
+++ b/templates/property.mustache
@@ -18,7 +18,9 @@ endif::alt-markdown-links[]
 {{#vendorExtensions}}
 {{#x-desc-more}}
 
+// tag::desc-more[]
 {{{this}}}
+// end::desc-more[]
 {{/x-desc-more}}
 {{/vendorExtensions}}
 {{! if ref is present, fetch remote description}}


### PR DESCRIPTION
Docs issue: DOC-13542

Porting template fixes forward from `capella` to `release/8.0`.

This does _not_ require uptake in `capella`.