### PR TITLE
NO ISSUE: Fix schema for Array models

### DIFF
--- a/docs/modules/fts-rest-nodes/pages/index.adoc
+++ b/docs/modules/fts-rest-nodes/pages/index.adoc
@@ -3521,7 +3521,6 @@ The name of the property is the name of the Search index.
 
 .Schema
 String
-
  array
 
 

--- a/templates/models.mustache
+++ b/templates/models.mustache
@@ -102,7 +102,7 @@ endif::collapse-models[]
 
 {{#items}}
 .Schema
-{{>schemas}} array
+{{>schema}} array
 {{/items}}
 {{/isArray}}
 {{/composedSchemas}}


### PR DESCRIPTION
Fixes schema of Array models so they are given as:

> String array

rather than:

> String
> ```
> array
> ```