### PR TITLE
DOC-13588: Issues with streaming completed requests

### DIFF
--- a/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
+++ b/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
@@ -826,7 +826,7 @@ components:
 
   ResponseAll:
     title: Links
-    description: These properties are common to all links.
+    description: Properties common to all links.
     type: object
     discriminator:
       propertyName: type
@@ -879,6 +879,7 @@ components:
 
   ResponseCouchbaseSpecific:
         title: Couchbase Specific Response
+        description: Properties specific to remote Couchbase links.
         type: object
         required:
           - activeHostname
@@ -1051,6 +1052,7 @@ components:
 
   ResponseS3Specific:
         title: S3 Specific Response
+        description: Properties specific to S3 links.
         type: object
         required:
           - accessKeyId
@@ -1101,6 +1103,7 @@ components:
 
   ResponseAzureBlobSpecific:
         title: Azure Blob Specific Response
+        description: Properties specific to Azure Blob links.
         type: object
         required:
           - endpoint
@@ -1205,6 +1208,7 @@ components:
 
   ResponseGCSSpecific:
         title: GCS Specific Response
+        description: Properties specific to Google Cloud Storage links.
         type: object
         required:
           - applicationDefaultCredentials

--- a/docs/modules/analytics-rest-links/pages/index.adoc
+++ b/docs/modules/analytics-rest-links/pages/index.adoc
@@ -4079,7 +4079,7 @@ endif::collapse-models[]
 
 ifdef::model-descriptions[]
 //tag::desc-ResponseAll[]
-These properties are common to all links.
+Properties common to all links.
 //end::desc-ResponseAll[]
 endif::model-descriptions[]
 
@@ -4199,14 +4199,47 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
+//tag::ResponseAzureBlob[]
 
-* xref:ResponseAll[]
+ifdef::model-descriptions[]
+//tag::desc-ResponseAzureBlob[]
+These properties are returned for Azure Blob links.
+//end::desc-ResponseAzureBlob[]
+endif::model-descriptions[]
+
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseAll, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseAll[]
 
 
-* xref:ResponseAzureBlobSpecific[]
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseAzureBlobSpecific, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseAzureBlobSpecific[]
 
 
+|===
+
+//end::ResponseAzureBlob[]
 
 
 // markup not found, no include::{specDir}definitions/ResponseAzureBlob/definition-end.adoc[opts=optional]
@@ -4238,6 +4271,11 @@ endif::collapse-models[]
 
 //tag::ResponseAzureBlobSpecific[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponseAzureBlobSpecific[]
+Properties specific to Azure Blob links.
+//end::desc-ResponseAzureBlobSpecific[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -4446,14 +4484,47 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
+//tag::ResponseCouchbase[]
 
-* xref:ResponseAll[]
+ifdef::model-descriptions[]
+//tag::desc-ResponseCouchbase[]
+These properties are returned for remote Couchbase links.
+//end::desc-ResponseCouchbase[]
+endif::model-descriptions[]
+
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseAll, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseAll[]
 
 
-* xref:ResponseCouchbaseSpecific[]
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseCouchbaseSpecific, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseCouchbaseSpecific[]
 
 
+|===
+
+//end::ResponseCouchbase[]
 
 
 // markup not found, no include::{specDir}definitions/ResponseCouchbase/definition-end.adoc[opts=optional]
@@ -4485,6 +4556,11 @@ endif::collapse-models[]
 
 //tag::ResponseCouchbaseSpecific[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponseCouchbaseSpecific[]
+Properties specific to remote Couchbase links.
+//end::desc-ResponseCouchbaseSpecific[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -4952,14 +5028,47 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
+//tag::ResponseGCS[]
 
-* xref:ResponseAll[]
+ifdef::model-descriptions[]
+//tag::desc-ResponseGCS[]
+These properties are returned for Google Cloud Storage links.
+//end::desc-ResponseGCS[]
+endif::model-descriptions[]
+
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseAll, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseAll[]
 
 
-* xref:ResponseGCSSpecific[]
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseGCSSpecific, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseGCSSpecific[]
 
 
+|===
+
+//end::ResponseGCS[]
 
 
 // markup not found, no include::{specDir}definitions/ResponseGCS/definition-end.adoc[opts=optional]
@@ -4991,6 +5100,11 @@ endif::collapse-models[]
 
 //tag::ResponseGCSSpecific[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponseGCSSpecific[]
+Properties specific to Google Cloud Storage links.
+//end::desc-ResponseGCSSpecific[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -5082,14 +5196,47 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
+//tag::ResponseS3[]
 
-* xref:ResponseAll[]
+ifdef::model-descriptions[]
+//tag::desc-ResponseS3[]
+These properties are returned for S3 links.
+//end::desc-ResponseS3[]
+endif::model-descriptions[]
+
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseAll, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseAll[]
 
 
-* xref:ResponseS3Specific[]
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponseS3Specific, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponseS3Specific[]
 
 
+|===
+
+//end::ResponseS3[]
 
 
 // markup not found, no include::{specDir}definitions/ResponseS3/definition-end.adoc[opts=optional]
@@ -5121,6 +5268,11 @@ endif::collapse-models[]
 
 //tag::ResponseS3Specific[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponseS3Specific[]
+Properties specific to S3 links.
+//end::desc-ResponseS3Specific[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===

--- a/docs/modules/analytics-rest-service/attachments/analytics-service.yaml
+++ b/docs/modules/analytics-rest-service/attachments/analytics-service.yaml
@@ -132,6 +132,7 @@ components:
   # Use YAML anchors for properties which are also available as query parameters
   ParametersCommon:
     title: Common Parameters
+    description: Parameters common with the Query Service.
     type: object
     required:
       - statement
@@ -210,6 +211,7 @@ components:
   # Use YAML anchors for properties which are also available as query parameters
   ParametersLocal:
     title: Analytics Parameters
+    description: Parameters specific to the Analytics Service.
     type: object
     properties:
       plan-format:
@@ -263,6 +265,7 @@ components:
   # For the Query Responses page
   ResponsesCommon:
         title: Common Responses
+        description: Responses common with the Query Service.
         type: object
         properties:
           requestID:
@@ -328,6 +331,7 @@ components:
   # For the Query Responses page
   ResponsesLocal:
         title: Analytics Responses
+        description: Responses specific to the Analytics Service.
         type: object
         properties:
           plans:

--- a/docs/modules/analytics-rest-service/pages/index.adoc
+++ b/docs/modules/analytics-rest-service/pages/index.adoc
@@ -1026,14 +1026,42 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
-
-* xref:ParametersCommon[]
+//tag::Parameters[]
 
 
-* xref:ParametersLocal[]
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ParametersCommon, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ParametersCommon[]
 
 
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ParametersLocal, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ParametersLocal[]
+
+
+|===
+
+//end::Parameters[]
 
 
 // markup not found, no include::{specDir}definitions/Parameters/definition-end.adoc[opts=optional]
@@ -1065,6 +1093,11 @@ endif::collapse-models[]
 
 //tag::ParametersCommon[]
 
+ifdef::model-descriptions[]
+//tag::desc-ParametersCommon[]
+Parameters common with the Query Service.
+//end::desc-ParametersCommon[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -1289,6 +1322,11 @@ endif::collapse-models[]
 
 //tag::ParametersLocal[]
 
+ifdef::model-descriptions[]
+//tag::desc-ParametersLocal[]
+Parameters specific to the Analytics Service.
+//end::desc-ParametersLocal[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -1441,14 +1479,42 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
-
-* xref:ResponsesCommon[]
+//tag::Responses[]
 
 
-* xref:ResponsesLocal[]
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponsesCommon, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponsesCommon[]
 
 
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-ResponsesLocal, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:ResponsesLocal[]
+
+
+|===
+
+//end::Responses[]
 
 
 // markup not found, no include::{specDir}definitions/Responses/definition-end.adoc[opts=optional]
@@ -1480,6 +1546,11 @@ endif::collapse-models[]
 
 //tag::ResponsesCommon[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponsesCommon[]
+Responses common with the Query Service.
+//end::desc-ResponsesCommon[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -1945,6 +2016,11 @@ endif::collapse-models[]
 
 //tag::ResponsesLocal[]
 
+ifdef::model-descriptions[]
+//tag::desc-ResponsesLocal[]
+Responses specific to the Analytics Service.
+//end::desc-ResponsesLocal[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===

--- a/docs/modules/eventing-rest-api/attachments/_overlay.json
+++ b/docs/modules/eventing-rest-api/attachments/_overlay.json
@@ -6,6 +6,12 @@
   },
   "actions": [
     {
+      "target": "components.schemas.handler_schema",
+      "update": {
+        "description": "An object which defines a function."
+      }
+    },
+    {
       "target": "components.schemas.settings_schema.properties.allow_sync_documents",
       "update": {
         "x-desc-status": "Couchbase Server 7.6.4",

--- a/docs/modules/eventing-rest-api/eventing.gradle
+++ b/docs/modules/eventing-rest-api/eventing.gradle
@@ -4,7 +4,7 @@ plugins {
 
 jayOverlay {
     targetFile.set("${projectDir}/build/bundle/eventing.yaml")
-    overlayFile.set("${projectDir}/attachments/overlay.json")
+    overlayFile.set("${projectDir}/attachments/_overlay.json")
     outputDir.set("${projectDir}/build/overlay")
 }
 

--- a/docs/modules/eventing-rest-api/pages/index.adoc
+++ b/docs/modules/eventing-rest-api/pages/index.adoc
@@ -7003,14 +7003,44 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-One of the following:
-
-* xref:handler_schema[]
+//tag::AddFunction[]
 
 
-* xref:handler_schema[]
+[cols="25,55,20",separator=¦]
+|===
+¦ One{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-handler_schema, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:handler_schema[]
+
+
+a¦ _or_
+a¦ 
+
+[markdown]
+--
+An array containing a single function definition object.
+--
+
+[%hardbreaks]
+*Minimum items:* `1`
+*Maximum items:* `1`
+{blank}
+a¦ xref:handler_schema[]
  array
 
+|===
+
+//end::AddFunction[]
 
 
 // markup not found, no include::{specDir}definitions/AddFunction/definition-end.adoc[opts=optional]
@@ -7040,14 +7070,43 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-One of the following:
-
-* xref:handler_schema[]
+//tag::AddFunctions[]
 
 
-* xref:handler_schema[]
+[cols="25,55,20",separator=¦]
+|===
+¦ One{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-handler_schema, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:handler_schema[]
+
+
+a¦ _or_
+a¦ 
+
+[markdown]
+--
+An array containing one or more function definition objects.
+--
+
+[%hardbreaks]
+*Minimum items:* `1`
+{blank}
+a¦ xref:handler_schema[]
  array
 
+|===
+
+//end::AddFunctions[]
 
 
 // markup not found, no include::{specDir}definitions/AddFunctions/definition-end.adoc[opts=optional]
@@ -7622,6 +7681,11 @@ endif::collapse-models[]
 
 //tag::handler_schema[]
 
+ifdef::model-descriptions[]
+//tag::desc-handler_schema[]
+An object which defines a function.
+//end::desc-handler_schema[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===

--- a/docs/modules/fts-rest-stats/pages/index.adoc
+++ b/docs/modules/fts-rest-stats/pages/index.adoc
@@ -563,14 +563,42 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
-
-* xref:clusterStats[]
+//tag::allStats[]
 
 
-* xref:indexStats[]
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-clusterStats, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:clusterStats[]
 
 
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-indexStats, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:indexStats[]
+
+
+|===
+
+//end::allStats[]
 
 
 // markup not found, no include::{specDir}definitions/allStats/definition-end.adoc[opts=optional]

--- a/docs/modules/index-rest-stats/attachments/indexes.yaml
+++ b/docs/modules/index-rest-stats/attachments/indexes.yaml
@@ -163,6 +163,7 @@ components:
   NodeIdxNode:
     type: object
     title: Nodes
+    description: Node statistics.
     required:
       - indexer
     properties:
@@ -218,12 +219,14 @@ components:
   PartIdxIndexes:
     type: object
     title: Indexes
+    description: Index statistics.
     additionalProperties:
       $ref: "#/components/schemas/PartIdxPartitionsIndex"
 
   PartIdxPartitions:
     type: object
     title: Partitions
+    description: Index partition statistics.
     additionalProperties:
       $ref: "#/components/schemas/PartIdxPartitionsIndex"
 

--- a/docs/modules/index-rest-stats/pages/index.adoc
+++ b/docs/modules/index-rest-stats/pages/index.adoc
@@ -1001,14 +1001,42 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
-
-* xref:NodeIdxNode[]
+//tag::NodeIdx[]
 
 
-* xref:PartIdxIndexes[]
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-NodeIdxNode, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:NodeIdxNode[]
 
 
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-PartIdxIndexes, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:PartIdxIndexes[]
+
+
+|===
+
+//end::NodeIdx[]
 
 
 // markup not found, no include::{specDir}definitions/NodeIdx/definition-end.adoc[opts=optional]
@@ -1040,6 +1068,11 @@ endif::collapse-models[]
 
 //tag::NodeIdxNode[]
 
+ifdef::model-descriptions[]
+//tag::desc-NodeIdxNode[]
+Node statistics.
+//end::desc-NodeIdxNode[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -1225,14 +1258,42 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
-All of the following:
-
-* xref:PartIdxIndexes[]
+//tag::PartIdx[]
 
 
-* xref:PartIdxPartitions[]
+[cols="25,55,20",separator=¦]
+|===
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
+
+a¦ 
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-PartIdxIndexes, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:PartIdxIndexes[]
 
 
+a¦ _and_
+a¦ 
+
+[markdown]
+--
+include::index.adoc[tag=desc-PartIdxPartitions, opts=optional]
+--
+
+[%hardbreaks]
+{blank}
+a¦ xref:PartIdxPartitions[]
+
+
+|===
+
+//end::PartIdx[]
 
 
 // markup not found, no include::{specDir}definitions/PartIdx/definition-end.adoc[opts=optional]
@@ -1264,6 +1325,11 @@ endif::collapse-models[]
 
 //tag::PartIdxIndexes[]
 
+ifdef::model-descriptions[]
+//tag::desc-PartIdxIndexes[]
+Index statistics.
+//end::desc-PartIdxIndexes[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===
@@ -1321,6 +1387,11 @@ endif::collapse-models[]
 
 //tag::PartIdxPartitions[]
 
+ifdef::model-descriptions[]
+//tag::desc-PartIdxPartitions[]
+Index partition statistics.
+//end::desc-PartIdxPartitions[]
+endif::model-descriptions[]
 
 [cols="25,55,20",separator=¦]
 |===

--- a/docs/modules/n1ql-rest-admin/pages/index.adoc
+++ b/docs/modules/n1ql-rest-admin/pages/index.adoc
@@ -5023,6 +5023,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
+
+endif::alt-markdown-links[]
 A unique string which tags a set of qualifiers.
 
 Refer to [Configure Completed Requests][sys-completed-config] for more information.
@@ -5538,7 +5542,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
-[client_context_id]: #client_context_id
+[client_context_id]: query-settings.html#client_context_id
 
 endif::alt-markdown-links[]
 The opaque ID or context provided by the client.
@@ -5959,6 +5963,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[auto-prepare]: ../n1ql-language-reference/prepare.html#auto-prepare
+
+endif::alt-markdown-links[]
 Specifies whether the query engine should create a prepared statement every time a SQL++ request is submitted, whether the PREPARE statement is included or not.
 
 Refer to [Auto-Prepare][auto-prepare] for more information.
@@ -6078,6 +6086,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
+
+endif::alt-markdown-links[]
 include::index.adoc[tag=desc-Logging_Parameters, opts=optional]
 --
 
@@ -6094,6 +6106,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
 [queryCompletedLimit]: #queryCompletedLimit
 
 endif::alt-markdown-links[]
@@ -6129,6 +6142,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
 [queryCompletedMaxPlanSize]: #queryCompletedMaxPlanSize
 
 endif::alt-markdown-links[]
@@ -6165,6 +6179,10 @@ a¦ [.status]##Couchbase Server 7.6.4##
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[sys-history]: monitoring-n1ql-query.html#sys-history
+
+endif::alt-markdown-links[]
 A file size in MiB.
 When specified, completed requests are saved to the Couchbase Server `logs` directory.
 Completed requests are saved to GZIP archives with the prefix `local_request_log`.
@@ -6192,6 +6210,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
 [queryCompletedThreshold]: #queryCompletedThreshold
 
 endif::alt-markdown-links[]
@@ -6421,6 +6440,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[max-parallelism]: ../n1ql-language-reference/index-partitioning.html#max-parallelism
 [queryMaxParallelism]: #queryMaxParallelism
 [max_parallelism_req]: #max_parallelism_req
 
@@ -6851,6 +6871,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[monitor-profile-details]: monitoring-n1ql-query.html#monitor-profile-details
 [profile_req]: #profile_req
 
 endif::alt-markdown-links[]

--- a/docs/modules/n1ql-rest-query/pages/index.adoc
+++ b/docs/modules/n1ql-rest-query/pages/index.adoc
@@ -867,7 +867,7 @@ endif::collapse-models[]
 ifdef::model-descriptions[]
 //tag::desc-Controls[]
 An object containing runtime information provided along with the request.
-Present only if `controls` was set to true in the [Request Parameters](#Request).
+Present only if `controls` was set to true in the request parameters.
 //end::desc-Controls[]
 endif::model-descriptions[]
 
@@ -1049,7 +1049,7 @@ endif::collapse-models[]
 
 ifdef::model-descriptions[]
 //tag::desc-Execution_Timings[]
-Present only if `profile` was set to `"timings"` in the [Request Parameters](#Request).
+Present only if `profile` was set to `"timings"` in the request parameters.
 
 The execution details for various phases involved in the query execution, such as kernel and service execution times, number of documents processed at each query operator in each phase, and number of phase switches.
 //end::desc-Execution_Timings[]
@@ -1329,7 +1329,7 @@ endif::collapse-models[]
 ifdef::model-descriptions[]
 //tag::desc-Profile[]
 An object containing monitoring and profiling information about the request.
-Present only if `profile` was set to `"phases"` or `"timings"` in the [Request Parameters](#Request).
+Present only if `profile` was set to `"phases"` or `"timings"` in the request parameters.
 //end::desc-Profile[]
 endif::model-descriptions[]
 
@@ -1484,6 +1484,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[section_srh_tlm_n1b]: #section_srh_tlm_n1b
+
+endif::alt-markdown-links[]
 Supplies the values for positional parameters in the statement.
 Applicable if the statement or prepared statement contains 1 or more positional parameters.
 
@@ -1541,6 +1545,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[auto-execute]: ../n1ql-language-reference/prepare.html#auto-execute
+
+endif::alt-markdown-links[]
 Specifies that prepared statements should be executed automatically as soon as they are created.
 This saves you from having to make two separate requests in cases where you want to prepare a statement and execute it immediately.
 
@@ -1986,6 +1994,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[execute]: ../n1ql-language-reference/execute.html
+
+endif::alt-markdown-links[]
 _Required_ if `statement` not provided.
 
 The name of the prepared SQL++ statement to be executed.
@@ -2186,6 +2198,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[transactional-scan-consistency]: #transactional-scan-consistency
+
+endif::alt-markdown-links[]
 Specifies the consistency guarantee or constraint for index scanning.
 The valid values are:
 
@@ -2602,6 +2618,10 @@ a¦ [.edition]##{enterprise}##
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[flex-indexes]: ../n1ql-language-reference/flex-indexes.html
+
+endif::alt-markdown-links[]
 Specifies that the query should use a Search index.
 
 If the query contains a `USING FTS` hint, that takes priority over this parameter.
@@ -2681,6 +2701,10 @@ a¦
 
 [markdown]
 --
+ifdef::alt-markdown-links[]
+[section_srh_tlm_n1b]: #section_srh_tlm_n1b
+
+endif::alt-markdown-links[]
 Supplies the value for a named parameter in the statement.
 Applicable if the statement or prepared statement contains 1 or more named parameters.
 
@@ -2771,7 +2795,7 @@ a¦
 
 [markdown]
 --
-The client context ID of the request, if one was supplied &mdash; see `client_context_id` in [Request Parameters](#Request).
+The client context ID of the request, if one was supplied &mdash; see `client_context_id` in the request parameters.
 --
 
 [%hardbreaks]

--- a/docs/modules/n1ql-rest-settings/pages/index.adoc
+++ b/docs/modules/n1ql-rest-settings/pages/index.adoc
@@ -1118,6 +1118,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
 [completed-limit]: #completed-limit
 
 endif::alt-markdown-links[]
@@ -1153,6 +1154,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
 [completed-max-plan-size]: #completed-max-plan-size
 
 endif::alt-markdown-links[]
@@ -1190,6 +1192,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[sys-completed-config]: monitoring-n1ql-query.html#sys-completed-config
 [completed-threshold]: #completed-threshold
 
 endif::alt-markdown-links[]
@@ -1277,6 +1280,7 @@ a¦
 [markdown]
 --
 ifdef::alt-markdown-links[]
+[max-parallelism]:  ../n1ql-language-reference/index-partitioning.html#max-parallelism
 [max-parallelism-srv]: #max-parallelism-srv
 [max_parallelism_req]: #max_parallelism_req
 

--- a/docs/modules/n1ql-rest-settings/pages/index.adoc
+++ b/docs/modules/n1ql-rest-settings/pages/index.adoc
@@ -1479,8 +1479,7 @@ If a request includes this parameter, it will be capped by the node-level `numat
 
 [%hardbreaks]
 *Default:* `1024`
-*Minimum:* `0`
-*Exclusive minimum:* `true`
+*Minimum:* `0` (exclusive)
 *Example:* `512`
 {blank}
 a¦ Integer (int32)

--- a/templates/models.mustache
+++ b/templates/models.mustache
@@ -114,7 +114,7 @@ endif::collapse-models[]
 {{#-first}}
 [cols="25,55,20",separator=¦]
 |===
-¦ One of ¦ ¦ Schema
+¦ One of ... ¦ ¦ Schema
 
 {{/-first}}
 a¦ {{^-first}}_or_{{/-first}}
@@ -128,7 +128,7 @@ a¦ {{>schemas}}
 {{#-first}}
 [cols="25,55,20",separator=¦]
 |===
-¦ Any of ¦ ¦ Schema
+¦ Any of ... ¦ ¦ Schema
 
 {{/-first}}
 a¦ {{^-first}}_and{nbsp}/ or_{{/-first}}
@@ -142,7 +142,7 @@ a¦ {{>schemas}}
 {{#-first}}
 [cols="25,55,20",separator=¦]
 |===
-¦ All of ¦ ¦ Schema
+¦ All of ... ¦ ¦ Schema
 
 {{/-first}}
 a¦ {{^-first}}_and_{{/-first}}

--- a/templates/models.mustache
+++ b/templates/models.mustache
@@ -111,22 +111,46 @@ endif::collapse-models[]
 {blank}
 
 {{#oneOf}}
-{{#-first}}One of the following:
+{{#-first}}
+[cols="25,55,20",separator=¦]
+|===
+¦ One of ¦ ¦ Schema
 
 {{/-first}}
-* {{>schemas}}
+a¦ {{^-first}}_or_{{/-first}}
+a¦ {{>property}}
+a¦ {{>schemas}}
+{{#-last}}
+|===
+{{/-last}}
 {{/oneOf}}
 {{#anyOf}}
-{{#-first}}Any of the following:
+{{#-first}}
+[cols="25,55,20",separator=¦]
+|===
+¦ Any of ¦ ¦ Schema
 
 {{/-first}}
-* {{>schemas}}
+a¦ {{^-first}}_and{nbsp}/ or_{{/-first}}
+a¦ {{>property}}
+a¦ {{>schemas}}
+{{#-last}}
+|===
+{{/-last}}
 {{/anyOf}}
 {{#allOf}}
-{{#-first}}All of the following:
+{{#-first}}
+[cols="25,55,20",separator=¦]
+|===
+¦ All of ¦ ¦ Schema
 
 {{/-first}}
-* {{>schemas}}
+a¦ {{^-first}}_and_{{/-first}}
+a¦ {{>property}}
+a¦ {{>schemas}}
+{{#-last}}
+|===
+{{/-last}}
 {{/allOf}}
 {{/composedSchemas}}
 

--- a/templates/models.mustache
+++ b/templates/models.mustache
@@ -110,11 +110,23 @@ endif::collapse-models[]
 .icon:bars[fw] Composite Schema
 {blank}
 
+{{! tag for partial}}
+//tag::{{name}}[]
+
+{{! Create partial model description }}
+{{#description}}
+ifdef::model-descriptions[]
+//tag::desc-{{name}}[]
+{{{unescapedDescription}}}
+//end::desc-{{name}}[]
+endif::model-descriptions[]
+{{/description}}
+
 {{#oneOf}}
 {{#-first}}
 [cols="25,55,20",separator=¦]
 |===
-¦ One of ... ¦ ¦ Schema
+¦ One{nbsp}of{nbsp}... ¦ ¦ Schema
 
 {{/-first}}
 a¦ {{^-first}}_or_{{/-first}}
@@ -128,7 +140,7 @@ a¦ {{>schemas}}
 {{#-first}}
 [cols="25,55,20",separator=¦]
 |===
-¦ Any of ... ¦ ¦ Schema
+¦ Any{nbsp}of{nbsp}... ¦ ¦ Schema
 
 {{/-first}}
 a¦ {{^-first}}_and{nbsp}/ or_{{/-first}}
@@ -142,7 +154,7 @@ a¦ {{>schemas}}
 {{#-first}}
 [cols="25,55,20",separator=¦]
 |===
-¦ All of ... ¦ ¦ Schema
+¦ All{nbsp}of{nbsp}... ¦ ¦ Schema
 
 {{/-first}}
 a¦ {{^-first}}_and_{{/-first}}
@@ -152,6 +164,9 @@ a¦ {{>schemas}}
 |===
 {{/-last}}
 {{/allOf}}
+
+{{! end tag for partial}}
+//end::{{name}}[]
 {{/composedSchemas}}
 
 {{! include partial after definition body }}

--- a/templates/param.mustache
+++ b/templates/param.mustache
@@ -33,20 +33,12 @@ include::index.adoc[tag=desc-{{dataType}}, opts=optional]
 {{/pattern}}
 {{! minimum value}}
 {{#minimum}}
-*Minimum:* `{{{minimum}}}`
+*Minimum:* `{{{minimum}}}`{{#exclusiveMinimum}} (exclusive){{/exclusiveMinimum}}
 {{/minimum}}
 {{! maximum value}}
 {{#maximum}}
-*Maximum:* `{{{maximum}}}`
+*Maximum:* `{{{maximum}}}`{{#exclusiveMaximum}} (exclusive){{/exclusiveMaximum}}
 {{/maximum}}
-{{! exclusive minimum value}}
-{{#exclusiveMinimum}}
-*Exclusive minimum:* `{{{exclusiveMinimum}}}`
-{{/exclusiveMinimum}}
-{{! exclusive maximum value}}
-{{#exclusiveMaximum}}
-*Exclusive maximum:* `{{{exclusiveMaximum}}}`
-{{/exclusiveMaximum}}
 {{! multiple of value}}
 {{#multipleOf}}
 *Multiple of:* `{{{multipleOf}}}`

--- a/templates/property.mustache
+++ b/templates/property.mustache
@@ -55,20 +55,12 @@ include::index.adoc[tag=desc-{{dataType}}, opts=optional]
 {{/pattern}}
 {{! minimum value}}
 {{#minimum}}
-*Minimum:* `{{{minimum}}}`
+*Minimum:* `{{{minimum}}}`{{#exclusiveMinimum}} (exclusive){{/exclusiveMinimum}}
 {{/minimum}}
 {{! maximum value}}
 {{#maximum}}
-*Maximum:* `{{{maximum}}}`
+*Maximum:* `{{{maximum}}}`{{#exclusiveMaximum}} (exclusive){{/exclusiveMaximum}}
 {{/maximum}}
-{{! exclusive minimum value}}
-{{#exclusiveMinimum}}
-*Exclusive minimum:* `{{{exclusiveMinimum}}}`
-{{/exclusiveMinimum}}
-{{! exclusive maximum value}}
-{{#exclusiveMaximum}}
-*Exclusive maximum:* `{{{exclusiveMaximum}}}`
-{{/exclusiveMaximum}}
 {{! multiple of value}}
 {{#multipleOf}}
 *Multiple of:* `{{{multipleOf}}}`


### PR DESCRIPTION
Docs issue: DOC-13588

- [x] Backport template fixes from #177 
- [x] Rebuild output documentation after Gerrit change [+234667](https://review.couchbase.org/c/query/+/234667)

Verify links in pages where static REST API content is transcluded:
- Server:
  * [Configure Queries](https://preview.docs-test.couchbase.com/docs-devex-DOC-13588-completed-reqs/server/current/n1ql/n1ql-manage/query-settings.html)
  * [Query Service REST API](https://preview.docs-test.couchbase.com/docs-devex-DOC-13588-completed-reqs/server/current/n1ql-rest-query/index.html)
  * [Query Admin REST API](https://preview.docs-test.couchbase.com/docs-devex-DOC-13588-completed-reqs/server/current/n1ql-rest-admin/index.html)
  * [Query Settings REST API](https://preview.docs-test.couchbase.com/docs-devex-DOC-13588-completed-reqs/server/current/n1ql-rest-settings/index.html)
- Capella:
  * [Manage and Monitor Queries](https://preview.docs-test.couchbase.com/docs-devex-DOC-13588-completed-reqs/cloud/n1ql/n1ql-manage/monitoring-n1ql-query.html)
  * [Configure Queries](https://preview.docs-test.couchbase.com/docs-devex-DOC-13588-completed-reqs/cloud/n1ql/n1ql-manage/query-settings.html)

Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-Couchbase-reviews)

The following PR updates the Manage and Monitor Queries and the Configure Queries pages.

- https://github.com/couchbaselabs/docs-devex/pull/434

