### PR TITLE
DOC-10413: Document REST endpoint to change LSS segment size

### DIFF
--- a/docs/modules/index-rest-settings/attachments/index-settings.yaml
+++ b/docs/modules/index-rest-settings/attachments/index-settings.yaml
@@ -97,11 +97,11 @@ components:
           x-has-example: true
           example: 67108864
           description: |-
-            For standard indexes using Plasma, the maximum size for Log Structured Store segment files (MB).
+            For standard indexes using Plasma, the maximum size for Log Structured Store segment files, in bytes.
             Index compaction and space reclamation are triggered when the segment file size reaches this value.
 
-            The default value is 512MB on Microsoft Windows and 4GB on GNU Linux and macOS.
-            Specifying a lower value (for example, 64 MB) may trigger index compaction more frequently in cases where an index uses a lot of disk space, or index fragmentation is high.
+            The default value is 512&nbsp;MiB on Microsoft Windows and 4&nbsp;GiB on GNU Linux and macOS.
+            Specifying a lower value (for example, 64&nbsp;MiB) may trigger index compaction more frequently in cases where an index uses a lot of disk space, or index fragmentation is high.
 
             This setting only applies to indexes created after the setting is changed.
             For existing indexes, you must rebuild the index after changing the setting.

--- a/docs/modules/index-rest-settings/attachments/index-settings.yaml
+++ b/docs/modules/index-rest-settings/attachments/index-settings.yaml
@@ -106,7 +106,7 @@ components:
             This setting only applies to indexes created after the setting is changed.
             For existing indexes, you must rebuild the index after changing the setting.
 
-            For more information, see [Standard Index Storage](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage).
+            For more information, see [Standard Index Storage](/server/8.0/indexes/storage-modes.html#standard-index-storage).
         indexer.rebalance.transferBatchSize:
           x-alt-title: indexer.&#8203;rebalance.&#8203;transferBatchSize
           type: integer
@@ -296,7 +296,7 @@ components:
           description: |-
             Whether Bloom filters are enabled for memory management.
 
-            For more information, see [Per Page Bloom Filters](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#per-page-bloom-filters).
+            For more information, see [Per Page Bloom Filters](/server/8.0/indexes/storage-modes.html#per-page-bloom-filters).
         indexer.settings.enable_shard_affinity:
           x-alt-title: indexer.&#8203;settings.&#8203;enable_shard_affinity
           type: boolean

--- a/docs/modules/index-rest-settings/attachments/index-settings.yaml
+++ b/docs/modules/index-rest-settings/attachments/index-settings.yaml
@@ -296,7 +296,7 @@ components:
           description: |-
             Whether Bloom filters are enabled for memory management.
 
-            For details, see [Per Page Bloom Filters](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#per-page-bloom-filters).
+            For more information, see [Per Page Bloom Filters](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#per-page-bloom-filters).
         indexer.settings.enable_shard_affinity:
           x-alt-title: indexer.&#8203;settings.&#8203;enable_shard_affinity
           type: boolean
@@ -592,7 +592,7 @@ components:
 
             * When false (the default), such redistribution does not occur.
 
-            For details, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
+            For more information, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
         indexer.settings.recovery.max_rollbacks:
           x-alt-title: indexer.&#8203;settings.&#8203;recovery.&#8203;max_rollbacks
           type: integer

--- a/docs/modules/index-rest-settings/attachments/index-settings.yaml
+++ b/docs/modules/index-rest-settings/attachments/index-settings.yaml
@@ -90,6 +90,23 @@ components:
     Settings:
       type: object
       properties:
+        indexer.plasma.LSSSegmentFileSize:
+          x-alt-title: indexer.&#8203;plasma.&#8203;LSSSegmentFileSize
+          type: integer
+          format: int32
+          x-has-example: true
+          example: 67108864
+          description: |-
+            For standard indexes using Plasma, the maximum size for Log Structured Store segment files (MB).
+            Index compaction and space reclamation are triggered when the segment file size reaches this value.
+
+            The default value is 512MB on Microsoft Windows and 4GB on GNU Linux and macOS.
+            Specifying a lower value (for example, 64 MB) may trigger index compaction more frequently in cases where an index uses a lot of disk space, or index fragmentation is high.
+
+            This setting only applies to indexes created after the setting is changed.
+            For existing indexes, you must rebuild the index after changing the setting.
+
+            For more information, see [Standard Index Storage](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage).
         indexer.rebalance.transferBatchSize:
           x-alt-title: indexer.&#8203;rebalance.&#8203;transferBatchSize
           type: integer

--- a/docs/modules/index-rest-settings/pages/index.adoc
+++ b/docs/modules/index-rest-settings/pages/index.adoc
@@ -564,11 +564,11 @@ a¦
 
 [markdown]
 --
-For standard indexes using Plasma, the maximum size for Log Structured Store segment files (MB).
+For standard indexes using Plasma, the maximum size for Log Structured Store segment files, in bytes.
 Index compaction and space reclamation are triggered when the segment file size reaches this value.
 
-The default value is 512MB on Microsoft Windows and 4GB on GNU Linux and macOS.
-Specifying a lower value (for example, 64 MB) may trigger index compaction more frequently in cases where an index uses a lot of disk space, or index fragmentation is high.
+The default value is 512&nbsp;MiB on Microsoft Windows and 4&nbsp;GiB on GNU Linux and macOS.
+Specifying a lower value (for example, 64&nbsp;MiB) may trigger index compaction more frequently in cases where an index uses a lot of disk space, or index fragmentation is high.
 
 This setting only applies to indexes created after the setting is changed.
 For existing indexes, you must rebuild the index after changing the setting.

--- a/docs/modules/index-rest-settings/pages/index.adoc
+++ b/docs/modules/index-rest-settings/pages/index.adoc
@@ -558,6 +558,30 @@ endif::collapse-models[]
 ¦ Property ¦ ¦ Schema
 
 a¦ 
+*indexer.&#8203;plasma.&#8203;LSSSegmentFileSize* +
+_optional_
+a¦ 
+
+[markdown]
+--
+For standard indexes using Plasma, the maximum size for Log Structured Store segment files (MB).
+Index compaction and space reclamation are triggered when the segment file size reaches this value.
+
+The default value is 512MB on Microsoft Windows and 4GB on GNU Linux and macOS.
+Specifying a lower value (for example, 64 MB) may trigger index compaction more frequently in cases where an index uses a lot of disk space, or index fragmentation is high.
+
+This setting only applies to indexes created after the setting is changed.
+For existing indexes, you must rebuild the index after changing the setting.
+
+For more information, see [Standard Index Storage](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage).
+--
+
+[%hardbreaks]
+*Example:* `67108864`
+{blank}
+a¦ Integer (int32)
+
+a¦ 
 *indexer.&#8203;rebalance.&#8203;transferBatchSize* +
 _optional_
 a¦ 
@@ -915,7 +939,7 @@ a¦
 --
 Whether Bloom filters are enabled for memory management.
 
-For details, see [Per Page Bloom Filters](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#per-page-bloom-filters).
+For more information, see [Per Page Bloom Filters](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#per-page-bloom-filters).
 --
 
 [%hardbreaks]
@@ -1487,7 +1511,7 @@ Whether to redistribute indexes on rebalance.
 
 * When false (the default), such redistribution does not occur.
 
-For details, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
+For more information, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
 --
 
 [%hardbreaks]

--- a/docs/modules/index-rest-settings/pages/index.adoc
+++ b/docs/modules/index-rest-settings/pages/index.adoc
@@ -573,7 +573,7 @@ Specifying a lower value (for example, 64 MB) may trigger index compaction more 
 This setting only applies to indexes created after the setting is changed.
 For existing indexes, you must rebuild the index after changing the setting.
 
-For more information, see [Standard Index Storage](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#standard-index-storage).
+For more information, see [Standard Index Storage](/server/8.0/indexes/storage-modes.html#standard-index-storage).
 --
 
 [%hardbreaks]
@@ -939,7 +939,7 @@ a¦
 --
 Whether Bloom filters are enabled for memory management.
 
-For more information, see [Per Page Bloom Filters](/server/8.0/learn/services-and-indexes/indexes/storage-modes.html#per-page-bloom-filters).
+For more information, see [Per Page Bloom Filters](/server/8.0/indexes/storage-modes.html#per-page-bloom-filters).
 --
 
 [%hardbreaks]


### PR DESCRIPTION
Jira issue: DOC-10413

Adds information about the `indexer.plasma.LSSSegmentFileSize` setting in the Indexer Settings page.

Docs preview:
* [Storage Settings](https://preview.docs-test.couchbase.com/docs-devex-DOC-10581-lss-compaction/server/current/indexes/storage-modes.html)
* [Index Settings REST API › Settings](https://preview.docs-test.couchbase.com/docs-devex-DOC-10581-lss-compaction/server/current/index-rest-settings/index.html#Settings)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

This PR must be merged at the same time as the following:

* https://github.com/couchbaselabs/docs-devex/pull/491