### PR TITLE
DOC-11373: incorrect statement regarding servicers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/
 ehthumbs.db
 Thumbs.db
 
+.openapi-generator
+.openapi-generator-ignore

--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -791,9 +791,7 @@ The minimum of that and the node-level `scan-cap` setting is applied. +
 |**servicers** +
 __optional__|[[servicers]]
 The number of service threads for the query.
-The default is 4 times the number of cores on the query node.
-
-Note that the overall node memory quota is this setting multiplied by the <<memory-quota-srv,node-level>> `memory-quota` setting. +
+The default is 4 times the number of cores on the query node. +
 **Default** : `32` +
 **Example** : `8`|integer (int32)
 |**timeout** +

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1574,8 +1574,6 @@ definitions:
           [[servicers]]
           The number of service threads for the query.
           The default is 4 times the number of cores on the query node.
-
-          Note that the overall node memory quota is this setting multiplied by the <<memory-quota-srv,node-level>> `memory-quota` setting.
       timeout:
         type: integer
         format: int64


### PR DESCRIPTION
Jira issue: DOC-11373

Applies to release/7.2; might as well fix it in 7.0 and 7.1. Note that the output documentation is not "built" because the cb-swagger workflow no longer works. I just updated the output doc by hand.