### PR TITLE
DOC-11134: Typo in Analytics Service REST API documentation

### DIFF
--- a/docs/modules/analytics/partials/rest-service/paths.adoc
+++ b/docs/modules/analytics/partials/rest-service/paths.adoc
@@ -164,7 +164,7 @@ __optional__|A named parameter value.|string|
 __optional__|The plan format.|enum (JSON, STRING)|`"JSON"`
 |**Query**|**logical-plan** +
 __optional__|If `true`, the logical plan is included in the query response.|boolean|`"false"`
-|**Query**|**organized-logical-plan** +
+|**Query**|**optimized-logical-plan** +
 __optional__|If `true`, the optimized logical plan is included in the query response.|boolean|`"true"`
 |**Query**|**expression-tree** +
 __optional__|If `true`, the expression tree is included in the query response.|boolean|`"false"`

--- a/src/analytics-service/swagger/analytics-service.yaml
+++ b/src/analytics-service/swagger/analytics-service.yaml
@@ -188,7 +188,7 @@ definitions:
         type: boolean
         description: If `true`, the logical plan is included in the query response.
         default: false
-      optimized-logical-plan: &organized_logical_plan
+      optimized-logical-plan: &optimized_logical_plan
         type: boolean
         description: If `true`, the optimized logical plan is included in the query response.
         default: true
@@ -479,8 +479,8 @@ parameters:
     required: false
 
   AnalyticsOptimizedLogicalPlan:
-    <<: *organized_logical_plan
-    name: organized-logical-plan
+    <<: *optimized_logical_plan
+    name: optimized-logical-plan
     in: query
     required: false
 


### PR DESCRIPTION
Jira issue: DOC-11134

Applies to release/7.2; might as well fix it in 7.0 and 7.1. Note that the output documentation is not "built" because the cb-swagger workflow no longer works. I just updated the output doc by hand.
