### PR TITLE
DOC-8634: numatrs should not be a request level parameter

### DIFF
--- a/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/admin/definitions.adoc
@@ -709,10 +709,7 @@ __optional__|[[numatrs-srv]]
 Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records].
 
 The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
-When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
-
-In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
-The minimum of that and the node-level `numatrs` setting is applied.|string
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.|string
 |**pipeline-batch** +
 __optional__|[[pipeline-batch-srv]]
 Controls the number of items execution operators can batch for Fetch from the KV.

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -229,8 +229,8 @@ __optional__|[[namespace]] Specifies the namespace to use. Currently, only the `
 **Example** : `"default"`|string
 |**numatrs** +
 __optional__|[[numatrs_req]]
-This parameter is ignored and has no effect.
-It's reserved for future use.|integer (int32)
+Reserved for future use.
+This parameter is ignored and has no effect.|integer (int32)
 |**pipeline_batch** +
 __optional__|[[pipeline_batch_req]]
 Controls the number of items execution operators can batch for Fetch from the KV.

--- a/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
+++ b/docs/modules/n1ql/partials/n1ql-rest-api/query/definitions.adoc
@@ -229,16 +229,8 @@ __optional__|[[namespace]] Specifies the namespace to use. Currently, only the `
 **Example** : `"default"`|string
 |**numatrs** +
 __optional__|[[numatrs_req]]
-Specifies the total number of {transactions-understanding-transactions}[active transaction records].
-Must be a positive integer.
-
-The {numatrs-srv}[node-level] `numatrs` setting specifies the default for this parameter for a single node.
-The request-level parameter overrides the node-level setting.
-
-In addition, the {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
-When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster. +
-**Default** : `1024` +
-**Example** : `512`|integer (int32)
+This parameter is ignored and has no effect.
+It's reserved for future use.|integer (int32)
 |**pipeline_batch** +
 __optional__|[[pipeline_batch_req]]
 Controls the number of items execution operators can batch for Fetch from the KV.

--- a/docs/modules/rest-api/partials/query-settings/definitions.adoc
+++ b/docs/modules/rest-api/partials/query-settings/definitions.adoc
@@ -204,10 +204,7 @@ __optional__|[[queryNumAtrs]]
 Specifies the total number of xref:learn:data/transactions.adoc#additional-storage-use[active transaction records] for all Query nodes in the cluster.
 
 The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
-When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
-
-In addition, there is a {numatrs_req}[request-level] `numatrs` parameter.
-If a request includes this parameter, it will be capped by the node-level `numatrs` setting. +
+When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster. +
 **Default** : `1024` +
 **Minimum value (exclusive)** : `0` +
 **Example** : `512`|integer (int32)

--- a/src/admin/swagger/admin.yaml
+++ b/src/admin/swagger/admin.yaml
@@ -1452,9 +1452,6 @@ definitions:
 
           The {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies this property for the whole cluster.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
-
-          In addition, the {numatrs_req}[request-level] `numatrs` parameter specifies this property per request.
-          The minimum of that and the node-level `numatrs` setting is applied.
       n1ql-feat-ctrl:
         type: integer
         format: int32

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -402,8 +402,8 @@ definitions:
         format: int32
         description: |
           [[numatrs_req]]
+          Reserved for future use.
           This parameter is ignored and has no effect.
-          It's reserved for future use.
       pipeline_batch:
         type: integer
         format: int32

--- a/src/query-service/swagger/query-service.yaml
+++ b/src/query-service/swagger/query-service.yaml
@@ -402,16 +402,8 @@ definitions:
         format: int32
         description: |
           [[numatrs_req]]
-          Specifies the total number of {transactions-understanding-transactions}[active transaction records].
-          Must be a positive integer.
-
-          The {numatrs-srv}[node-level] `numatrs` setting specifies the default for this parameter for a single node.
-          The request-level parameter overrides the node-level setting.
-
-          In addition, the {queryNumAtrs}[cluster-level] `queryNumAtrs` setting specifies the default for this parameter for the whole cluster.
-          When you change the cluster-level setting, the node-level setting is overwritten for all nodes in the cluster.
-        default: 1024
-        example: 512
+          This parameter is ignored and has no effect.
+          It's reserved for future use.
       pipeline_batch:
         type: integer
         format: int32

--- a/src/query-settings/swagger/query-settings.yaml
+++ b/src/query-settings/swagger/query-settings.yaml
@@ -274,9 +274,6 @@ definitions:
 
           The {numatrs-srv}[node-level] `numatrs` setting specifies this property for a single node.
           When you change the cluster-level setting, the node-level setting is over-written for all nodes in the cluster.
-
-          In addition, there is a {numatrs_req}[request-level] `numatrs` parameter.
-          If a request includes this parameter, it will be capped by the node-level `numatrs` setting.
       queryPipelineBatch:
         type: integer
         format: int32


### PR DESCRIPTION
Jira issue: DOC-8634

The `numatrs` request-level parameter still exists, but from discussion on the Jira ticket, it seems that it currently has no effect and is reserved for future use. I don't want to remove the request-level parameter from the documentation entirely, but I've updated its description as above, and removed the links to the request-level parameter from the equivalent node-level and cluster-level settings.

Docs preview:
- [Query Service REST API](https://preview.docs-test.couchbase.com/docs-server-DOC-8634-numatrs-req/server/current/n1ql/n1ql-rest-api/index.html#numatrs_req)
- [Query Admin REST API](https://preview.docs-test.couchbase.com/docs-server-DOC-8634-numatrs-req/server/current/n1ql/n1ql-rest-api/admin.html#numatrs-srv)
- [Query Settings REST API](https://preview.docs-test.couchbase.com/docs-server-DOC-8634-numatrs-req/server/current/rest-api/rest-cluster-query-settings.html#queryNumAtrs)

You will need the [Docs Team credentials](https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords) on Confluence.

This PR must be merged at the same time as the following:

- https://github.com/couchbase/docs-server/pull/4030
- https://github.com/couchbaselabs/docs-devex/pull/517

Backport to the following branches:

- [x] `release/7.0` (unsupported)
- [x] `release/7.1` (unsupported)

In 7.6, the REST API specs were migrated to the `query` repo. Merge to the following branches:

- [x] `trinity`
- [x] `morpheus`

And rebuild the `release/7.6`, `release/8.0`, and `capella` branches here.