### PR TITLE
TOTORO: Initial setup of release/8.1 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Gradle CI
 
 on:
   pull_request:
-    branches: [ release/8.0 ]
+    branches: [ release/8.1 ]
   merge_group:
     types: [checks_requested]
 

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,2 +1,2 @@
 name: server
-version: '8.0'
+version: '8.1'

--- a/docs/modules/analytics-rest-admin/attachments/analytics-admin.yaml
+++ b/docs/modules/analytics-rest-admin/attachments/analytics-admin.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Analytics Administration REST APIs
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |
     The Analytics Administration REST APIs are provided by the Analytics service.
     These APIs enables you to manage and monitor the Analytics service.
@@ -749,7 +749,7 @@ components:
 
 
       Returns an object containing an error message.
-      Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+      Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
     content:
       application/json:
         schema:

--- a/docs/modules/analytics-rest-admin/pages/index.adoc
+++ b/docs/modules/analytics-rest-admin/pages/index.adoc
@@ -33,7 +33,7 @@ These APIs enables you to manage and monitor the Analytics service.
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information
@@ -276,7 +276,7 @@ a|
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -435,7 +435,7 @@ a| xref:Status[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -595,7 +595,7 @@ a| xref:Request[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -754,7 +754,7 @@ a| xref:Ingestion[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -917,7 +917,7 @@ a| xref:Mutations[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -1076,7 +1076,7 @@ a| Object
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -1235,7 +1235,7 @@ a| Object
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 
@@ -1395,7 +1395,7 @@ a| xref:Request[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html). 
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html). 
 --
 a| Object
 

--- a/docs/modules/analytics-rest-config/attachments/analytics-config.yaml
+++ b/docs/modules/analytics-rest-config/attachments/analytics-config.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Analytics Configuration REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |
     The Analytics Configuration REST API is provided by the Analytics service.
     This API enables you to configure Analytics nodes and clusters.
@@ -61,7 +61,7 @@ paths:
         IMPORTANT: For the configuration changes to take effect,
         you must restart the Analytics cluster using the [Cluster Restart API][1].
 
-        [1]: /server/8.0/analytics-rest-admin.html#restart_cluster
+        [1]: /server/8.1/analytics-rest-admin.html#restart_cluster
       requestBody:
         description: An object specifying one or more of the configurable service-level parameters.
         content:
@@ -109,8 +109,8 @@ paths:
         you must restart the node using the [Node Restart API][1],
         or restart the Analytics cluster using the [Cluster Restart API][2].
 
-        [1]: /server/8.0/analytics-rest-admin.html#restart_node
-        [2]: /server/8.0/analytics-rest-admin.html#restart_cluster
+        [1]: /server/8.1/analytics-rest-admin.html#restart_node
+        [2]: /server/8.1/analytics-rest-admin.html#restart_cluster
       requestBody:
         description: An object specifying one or more of the configurable node-level parameters on this node.
         content:
@@ -301,8 +301,8 @@ components:
           Note that JVM arguments are generally not secure, and are exposed by [cbcollect_info][1] and the [System Event][2] log.
           To pass arguments opaquely, you may use [Java command-line argument files][3].
 
-          [1]: /server/8.0/cli/cbcollect-info-tool.html
-          [2]: /server/8.0/learn/clusters-and-availability/system-events.html
+          [1]: /server/8.1/cli/cbcollect-info-tool.html
+          [2]: /server/8.1/learn/clusters-and-availability/system-events.html
           [3]: https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-4856361B-8BFD-4964-AE84-121F5F6CF111
         type: string
         nullable: true
@@ -450,8 +450,8 @@ components:
           Note that JVM arguments are generally not secure, and are exposed by [cbcollect_info][1] and the [System Event][2] log.
           To pass arguments opaquely, you may use [Java command-line argument files][3].
 
-          [1]: /server/8.0/cli/cbcollect-info-tool.html
-          [2]: /server/8.0/learn/clusters-and-availability/system-events.html
+          [1]: /server/8.1/cli/cbcollect-info-tool.html
+          [2]: /server/8.1/learn/clusters-and-availability/system-events.html
           [3]: https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-4856361B-8BFD-4964-AE84-121F5F6CF111
         type: string
         nullable: true
@@ -500,7 +500,7 @@ components:
       The user name or password may be incorrect.
 
       Returns an object containing an error message.
-      Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+      Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
     content:
       application/json:
         schema:

--- a/docs/modules/analytics-rest-config/pages/index.adoc
+++ b/docs/modules/analytics-rest-config/pages/index.adoc
@@ -33,7 +33,7 @@ This API enables you to configure Analytics nodes and clusters.
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information
@@ -223,7 +223,7 @@ a| xref:Node[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
 --
 a| Object
 
@@ -376,7 +376,7 @@ a| xref:Service[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
 --
 a| Object
 
@@ -481,8 +481,8 @@ IMPORTANT: For the configuration changes to take effect,
 you must restart the node using the [Node Restart API][1],
 or restart the Analytics cluster using the [Cluster Restart API][2].
 
-[1]: /server/8.0/analytics-rest-admin.html#restart_node
-[2]: /server/8.0/analytics-rest-admin.html#restart_cluster
+[1]: /server/8.1/analytics-rest-admin.html#restart_node
+[2]: /server/8.1/analytics-rest-admin.html#restart_cluster
 --
 
 
@@ -587,7 +587,7 @@ a| xref:Errors[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
 --
 a| Object
 
@@ -691,7 +691,7 @@ Modifies service-level parameters, which apply to all nodes running the Analytic
 IMPORTANT: For the configuration changes to take effect,
 you must restart the Analytics cluster using the [Cluster Restart API][1].
 
-[1]: /server/8.0/analytics-rest-admin.html#restart_cluster
+[1]: /server/8.1/analytics-rest-admin.html#restart_cluster
 --
 
 
@@ -796,7 +796,7 @@ a| xref:Errors[]
 | 401
 a| [markdown]
 --
-Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+Unauthorized. The user name or password may be incorrect.  Returns an object containing an error message. Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
 --
 a| Object
 
@@ -998,8 +998,8 @@ If the same JVM argument appears in both the service-level arguments and the nod
 Note that JVM arguments are generally not secure, and are exposed by [cbcollect_info][1] and the [System Event][2] log.
 To pass arguments opaquely, you may use [Java command-line argument files][3].
 
-[1]: /server/8.0/cli/cbcollect-info-tool.html
-[2]: /server/8.0/learn/clusters-and-availability/system-events.html
+[1]: /server/8.1/cli/cbcollect-info-tool.html
+[2]: /server/8.1/learn/clusters-and-availability/system-events.html
 [3]: https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-4856361B-8BFD-4964-AE84-121F5F6CF111
 --
 
@@ -1475,8 +1475,8 @@ The default is undefined (null).
 Note that JVM arguments are generally not secure, and are exposed by [cbcollect_info][1] and the [System Event][2] log.
 To pass arguments opaquely, you may use [Java command-line argument files][3].
 
-[1]: /server/8.0/cli/cbcollect-info-tool.html
-[2]: /server/8.0/learn/clusters-and-availability/system-events.html
+[1]: /server/8.1/cli/cbcollect-info-tool.html
+[2]: /server/8.1/learn/clusters-and-availability/system-events.html
 [3]: https://docs.oracle.com/en/java/javase/11/tools/java.html#GUID-4856361B-8BFD-4964-AE84-121F5F6CF111
 --
 

--- a/docs/modules/analytics-rest-library/attachments/analytics-library.yaml
+++ b/docs/modules/analytics-rest-library/attachments/analytics-library.yaml
@@ -4,7 +4,7 @@ info:
   version: '0.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |
     The Analytics Library REST API is provided by the Analytics service.
     This API enables you to manage the libraries that are used to create SQL\+\+ for Analytics user-defined functions.

--- a/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
+++ b/docs/modules/analytics-rest-links/attachments/analytics-links.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Analytics Links REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |-
     The Analytics Links REST API is provided by the Analytics service.
     This API enables you to manage the links to remote Couchbase clusters and external data sources.

--- a/docs/modules/analytics-rest-links/pages/index.adoc
+++ b/docs/modules/analytics-rest-links/pages/index.adoc
@@ -32,7 +32,7 @@ This API enables you to manage the links to remote Couchbase clusters and extern
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information

--- a/docs/modules/analytics-rest-service/attachments/analytics-service.yaml
+++ b/docs/modules/analytics-rest-service/attachments/analytics-service.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Analytics Service REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |
     The Analytics Service REST API is provided by the Analytics service.
     This API enables you to run Analytics queries and set request-level parameters.
@@ -355,7 +355,7 @@ components:
         type: string
         description: >
           A message describing the error in detail.
-          Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+          Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
 
   # For the Query Responses page
   ResponsesCommonWarnings:

--- a/docs/modules/analytics-rest-service/pages/index.adoc
+++ b/docs/modules/analytics-rest-service/pages/index.adoc
@@ -33,7 +33,7 @@ This API enables you to run Analytics queries and set request-level parameters.
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information
@@ -1706,7 +1706,7 @@ a¦
 
 [markdown]
 --
-A message describing the error in detail. Refer to [Error Codes](/server/8.0/analytics/error-codes.html).
+A message describing the error in detail. Refer to [Error Codes](/server/8.1/analytics/error-codes.html).
 
 --
 

--- a/docs/modules/analytics-rest-settings/attachments/analytics-settings.yaml
+++ b/docs/modules/analytics-rest-settings/attachments/analytics-settings.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Analytics Settings REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |
     The Analytics Settings REST API is provided by the Analytics service.
     This API enables you to view or set cluster-level Analytics settings.

--- a/docs/modules/analytics-rest-settings/pages/index.adoc
+++ b/docs/modules/analytics-rest-settings/pages/index.adoc
@@ -33,7 +33,7 @@ This API enables you to view or set cluster-level Analytics settings.
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information

--- a/docs/modules/eventing-rest-api/attachments/eventing.yaml
+++ b/docs/modules/eventing-rest-api/attachments/eventing.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Eventing REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |-
     The Eventing REST API provides methods to work with and manipulate Couchbase Eventing functions.
 
@@ -931,7 +931,7 @@ components:
           type: boolean
           description: |-
             Enables the Eventing curl function.
-            For details, see [cURL](/server/8.0/eventing/eventing-curl-spec.html).
+            For details, see [cURL](/server/8.1/eventing/eventing-curl-spec.html).
 
             This setting is available globally or at the function scope level.
         enable_debugger:
@@ -940,7 +940,7 @@ components:
           x-has-default: true
           description: |-
             Enables the Eventing service debugger.
-            For details, see [Debugging and Diagnosability](/server/8.0/eventing/eventing-debugging-and-diagnosability.html).
+            For details, see [Debugging and Diagnosability](/server/8.1/eventing/eventing-debugging-and-diagnosability.html).
 
             This setting is available globally or at the function scope level.
         cursor_limit:
@@ -962,7 +962,6 @@ components:
           type: integer
           example: 3
           x-has-example: true
-          x-desc-status: Couchbase Server 8.0
           description: |-
             The number of Eventing nodes on which the functions in scope execute.
 

--- a/docs/modules/eventing-rest-api/pages/index.adoc
+++ b/docs/modules/eventing-rest-api/pages/index.adoc
@@ -31,7 +31,7 @@ The Eventing REST API provides methods to work with and manipulate Couchbase Eve
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information
@@ -8502,7 +8502,7 @@ a¦
 [markdown]
 --
 Enables the Eventing curl function.
-For details, see [cURL](/server/8.0/eventing/eventing-curl-spec.html).
+For details, see [cURL](/server/8.1/eventing/eventing-curl-spec.html).
 
 This setting is available globally or at the function scope level.
 --
@@ -8519,7 +8519,7 @@ a¦
 [markdown]
 --
 Enables the Eventing service debugger.
-For details, see [Debugging and Diagnosability](/server/8.0/eventing/eventing-debugging-and-diagnosability.html).
+For details, see [Debugging and Diagnosability](/server/8.1/eventing/eventing-debugging-and-diagnosability.html).
 
 This setting is available globally or at the function scope level.
 --
@@ -8556,7 +8556,7 @@ a¦ Integer
 a¦ 
 *num_nodes_running* +
 _optional_
-a¦ [.status]##Couchbase Server 8.0##
+a¦ 
 
 [markdown]
 --

--- a/docs/modules/fts-rest-advanced/search-advanced.gradle
+++ b/docs/modules/fts-rest-advanced/search-advanced.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/advanced/examples")
+                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/advanced/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/get-partition.json")
@@ -13,7 +13,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/advanced/advanced.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/advanced/advanced.yaml"
     outputDir = "${rootDir}/docs/modules/fts-rest-advanced/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "cbft"

--- a/docs/modules/fts-rest-indexing/search-index.gradle
+++ b/docs/modules/fts-rest-indexing/search-index.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/index/examples")
+                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/index/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/d-api-index-name-200.json")
@@ -39,7 +39,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/index/index.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/index/index.yaml"
     outputDir = "${rootDir}/docs/modules/fts-rest-indexing/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "cbft"

--- a/docs/modules/fts-rest-manage/search-manage.gradle
+++ b/docs/modules/fts-rest-manage/search-manage.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/manage/examples")
+                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/manage/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/file-xfer-200.json")
@@ -16,7 +16,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/manage/manage.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/manage/manage.yaml"
     outputDir = "${rootDir}/docs/modules/fts-rest-manage/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "cbft"

--- a/docs/modules/fts-rest-nodes/search-nodes.gradle
+++ b/docs/modules/fts-rest-nodes/search-nodes.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/nodes/examples")
+                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/nodes/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/get-cluster-config.json")
@@ -15,7 +15,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/nodes/nodes.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/nodes/nodes.yaml"
     outputDir = "${rootDir}/docs/modules/fts-rest-nodes/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "cbft"

--- a/docs/modules/fts-rest-query/search-query.gradle
+++ b/docs/modules/fts-rest-query/search-query.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/query/examples")
+                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/query/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/api-query-all.json")
@@ -20,7 +20,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/query/query.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/query/query.yaml"
     outputDir = "${rootDir}/docs/modules/fts-rest-query/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "cbft"

--- a/docs/modules/fts-rest-stats/search-stats.gradle
+++ b/docs/modules/fts-rest-stats/search-stats.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/stats/examples")
+                value: "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/stats/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/g-api-nsstats-200.json")
@@ -15,7 +15,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/morpheus/docs/spec/stats/stats.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/cbft/refs/heads/master/docs/spec/stats/stats.yaml"
     outputDir = "${rootDir}/docs/modules/fts-rest-stats/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "cbft"

--- a/docs/modules/index-rest-settings/attachments/index-settings.yaml
+++ b/docs/modules/index-rest-settings/attachments/index-settings.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Index Settings REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |-
     The Index Settings REST API is provided by the Index Service.
     This API enables you to retrieve or set Index Service settings.
@@ -106,7 +106,7 @@ components:
             This setting only applies to indexes created after the setting is changed.
             For existing indexes, you must rebuild the index after changing the setting.
 
-            For more information, see [Standard Index Storage](/server/8.0/indexes/storage-modes.html#standard-index-storage).
+            For more information, see [Standard Index Storage](/server/8.1/indexes/storage-modes.html#standard-index-storage).
         indexer.rebalance.transferBatchSize:
           x-alt-title: indexer.&#8203;rebalance.&#8203;transferBatchSize
           type: integer
@@ -124,7 +124,7 @@ components:
             This setting controls the maximum number of indexes that a rebalance rebuilds concurrently.
             You must have the Full Admin or the Cluster Admin role to set this value.
 
-            For an overview of rebalance as it affects the Index Service, including an overview of smart batching, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
+            For an overview of rebalance as it affects the Index Service, including an overview of smart batching, see [Rebalance](/server/8.1/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
         indexer.settings.allow_large_keys:
           x-alt-title: indexer.&#8203;settings.&#8203;allow_large_keys
           type: boolean
@@ -296,7 +296,7 @@ components:
           description: |-
             Whether Bloom filters are enabled for memory management.
 
-            For more information, see [Per Page Bloom Filters](/server/8.0/indexes/storage-modes.html#per-page-bloom-filters).
+            For more information, see [Per Page Bloom Filters](/server/8.1/indexes/storage-modes.html#per-page-bloom-filters).
         indexer.settings.enable_shard_affinity:
           x-alt-title: indexer.&#8203;settings.&#8203;enable_shard_affinity
           type: boolean
@@ -304,7 +304,7 @@ components:
           default: false
           description: |-
             Selects the index rebalance method.
-            See [Index Rebalance Methods](/server/8.0/learn/clusters-and-availability/rebalance.html#index-rebalance-methods).
+            See [Index Rebalance Methods](/server/8.1/learn/clusters-and-availability/rebalance.html#index-rebalance-methods).
 
             * If false (the default), Index Service nodes rebuild indexes that are newly assigned to them during a rebalance.
 
@@ -592,7 +592,7 @@ components:
 
             * When false (the default), such redistribution does not occur.
 
-            For more information, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
+            For more information, see [Rebalance](/server/8.1/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
         indexer.settings.recovery.max_rollbacks:
           x-alt-title: indexer.&#8203;settings.&#8203;recovery.&#8203;max_rollbacks
           type: integer

--- a/docs/modules/index-rest-settings/pages/index.adoc
+++ b/docs/modules/index-rest-settings/pages/index.adoc
@@ -36,7 +36,7 @@ Unless otherwise noted, you should only change the Index Service settings when a
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information
@@ -573,7 +573,7 @@ Specifying a lower value (for example, 64&nbsp;MiB) may trigger index compaction
 This setting only applies to indexes created after the setting is changed.
 For existing indexes, you must rebuild the index after changing the setting.
 
-For more information, see [Standard Index Storage](/server/8.0/indexes/storage-modes.html#standard-index-storage).
+For more information, see [Standard Index Storage](/server/8.1/indexes/storage-modes.html#standard-index-storage).
 --
 
 [%hardbreaks]
@@ -595,7 +595,7 @@ Couchbase Server breaks the rebuilding of indexes during a rebalance into batche
 This setting controls the maximum number of indexes that a rebalance rebuilds concurrently.
 You must have the Full Admin or the Cluster Admin role to set this value.
 
-For an overview of rebalance as it affects the Index Service, including an overview of smart batching, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
+For an overview of rebalance as it affects the Index Service, including an overview of smart batching, see [Rebalance](/server/8.1/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
 --
 
 [%hardbreaks]
@@ -939,7 +939,7 @@ a¦
 --
 Whether Bloom filters are enabled for memory management.
 
-For more information, see [Per Page Bloom Filters](/server/8.0/indexes/storage-modes.html#per-page-bloom-filters).
+For more information, see [Per Page Bloom Filters](/server/8.1/indexes/storage-modes.html#per-page-bloom-filters).
 --
 
 [%hardbreaks]
@@ -955,7 +955,7 @@ a¦
 [markdown]
 --
 Selects the index rebalance method.
-See [Index Rebalance Methods](/server/8.0/learn/clusters-and-availability/rebalance.html#index-rebalance-methods).
+See [Index Rebalance Methods](/server/8.1/learn/clusters-and-availability/rebalance.html#index-rebalance-methods).
 
 * If false (the default), Index Service nodes rebuild indexes that are newly assigned to them during a rebalance.
 
@@ -1511,7 +1511,7 @@ Whether to redistribute indexes on rebalance.
 
 * When false (the default), such redistribution does not occur.
 
-For more information, see [Rebalance](/server/8.0/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
+For more information, see [Rebalance](/server/8.1/learn/clusters-and-availability/rebalance.html#rebalancing-the-index-service).
 --
 
 [%hardbreaks]

--- a/docs/modules/index-rest-stats/attachments/indexes.yaml
+++ b/docs/modules/index-rest-stats/attachments/indexes.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.3
 info:
   title: Index Statistics REST API
-  version: '8.0'
+  version: '8.1'
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
   description: |-
     The Index Statistics REST API is provided by the Index service.
     This API enables you to get Index service statistics.

--- a/docs/modules/index-rest-stats/pages/index.adoc
+++ b/docs/modules/index-rest-stats/pages/index.adoc
@@ -32,7 +32,7 @@ This API enables you to get Index service statistics.
 [discrete#version]
 = Version information
 [%hardbreaks]
-__Version__ : 8.0
+__Version__ : 8.1
 
 [discrete#host]
 = Host information

--- a/docs/modules/n1ql-rest-admin/admin.gradle
+++ b/docs/modules/n1ql-rest-admin/admin.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/admin/examples")
+                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/admin/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/get_debug_vars.html")
@@ -16,7 +16,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/admin/admin.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/admin/admin.yaml"
     outputDir = "${rootDir}/docs/modules/n1ql-rest-admin/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "query"

--- a/docs/modules/n1ql-rest-functions/functions.gradle
+++ b/docs/modules/n1ql-rest-functions/functions.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/functions/examples")
+                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/functions/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/delete_library_global.sh")
@@ -27,7 +27,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/functions/functions.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/functions/functions.yaml"
     outputDir = "${rootDir}/docs/modules/n1ql-rest-functions/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "query"

--- a/docs/modules/n1ql-rest-query/query-service.gradle
+++ b/docs/modules/n1ql-rest-query/query-service.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/service/examples")
+                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/service/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/exformdata.sh")
@@ -28,7 +28,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/service/service.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/service/service.yaml"
     outputDir = "${rootDir}/docs/modules/n1ql-rest-query/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "query"

--- a/docs/modules/n1ql-rest-settings/query-settings.gradle
+++ b/docs/modules/n1ql-rest-settings/query-settings.gradle
@@ -3,7 +3,7 @@ apply plugin: 'org.openapi.generator'
 tasks.register('getExamples') {
   doLast {
     ant.property(name: "srcUrl",
-                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/settings/examples")
+                value: "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/settings/examples")
     ant.echo("Fetching from ${ant.srcUrl}")
     ant.get(dest: "examples", ignoreerrors: "true") {
       ant.url(url: "${ant.srcUrl}/query-settings-get-access.jsonc")
@@ -21,7 +21,7 @@ tasks.register('getExamples') {
 
 openApiGenerate {
     generatorName = "asciidoc"
-    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/morpheus/docs/spec/settings/settings.yaml"
+    remoteInputSpec = "https://raw.githubusercontent.com/couchbase/query/refs/heads/master/docs/spec/settings/settings.yaml"
     outputDir = "${rootDir}/docs/modules/n1ql-rest-settings/pages"
     templateDir = "${rootDir}/templates"
     gitRepoId = "query"

--- a/docs/modules/ns_server/attachments/new_spec.yaml
+++ b/docs/modules/ns_server/attachments/new_spec.yaml
@@ -5,7 +5,7 @@ info:
   version: 4.6.1
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
 
 host: localhost:8091
 

--- a/docs/modules/ns_server/attachments/ns_server.yaml
+++ b/docs/modules/ns_server/attachments/ns_server.yaml
@@ -5,7 +5,7 @@ info:
   version: "4.5.1"
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
 
 host: localhost:8091
 

--- a/docs/modules/view_engine/attachments/view_engine.yaml
+++ b/docs/modules/view_engine/attachments/view_engine.yaml
@@ -5,7 +5,7 @@ info:
   version: "4.5.1"
   license:
     name: Business Source License 1.1
-    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.0/licenses/BSL-Couchbase.txt
+    url: https://github.com/couchbaselabs/cb-swagger/blob/release/8.1/licenses/BSL-Couchbase.txt
 
 host: localhost:1337/192.168.99.100:8092
 

--- a/docs/preview/HEAD.yml
+++ b/docs/preview/HEAD.yml
@@ -1,7 +1,7 @@
 sources:
   docs-server:
-    branches: release/8.0
+    branches: release/8.1
   docs-analytics:
-    branches: release/8.0
+    branches: release/8.1
   docs-devex:
-    branches: release/8.0
+    branches: release/8.1

--- a/licenses/BSL-Couchbase.txt
+++ b/licenses/BSL-Couchbase.txt
@@ -2,7 +2,7 @@ COUCHBASE BUSINESS SOURCE LICENSE AGREEMENT
 
 Business Source License 1.1
 Licensor:  Couchbase, Inc.
-Licensed Work:  Couchbase Server Version 8.0
+Licensed Work:  Couchbase Server Version 8.1
 The Licensed Work is © 2021-Present Couchbase, Inc.
 
 Additional Use Grant: You may make production use of the Licensed Work, provided


### PR DESCRIPTION
The `totoro` branch is not yet available in the `query` and `cbft` repos. I've gone with `master` for now, but this will have to be updated later.