### PR TITLE
DOC-14222: Include example descriptions from OpenAPI spec

### DIFF
--- a/docs/modules/fts-rest-query/pages/index.adoc
+++ b/docs/modules/fts-rest-query/pages/index.adoc
@@ -313,6 +313,8 @@ include::{snippetDir}api-query/http-response.adoc[opts=optional]
 ====
 [#api-query-ex-response-200-0]
 .All active node queries
+All active queries across the Search cluster.
+
 [source,json]
 ----
 {
@@ -381,6 +383,8 @@ include::{snippetDir}api-query/http-response.adoc[opts=optional]
 
 [#api-query-ex-response-200-1]
 .All active node queries (filtered)
+All queries across the cluster running for longer than 7&nbsp;s.
+
 [source,json]
 ----
 {

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -338,6 +338,10 @@ include::{snippetDir}{{operationIdOriginal}}/curl-request.adoc[opts=optional]
 {{#if @last}}{{#if @index}}{{> curlTitle}}
 {{/if}}{{else}}{{> curlTitle}}
 {{/if ~}}
+{{#with description~}}
+{{{this}}}
+
+{{/with~}}
 [source,sh]
 ----
 {{{source}}}

--- a/templates/requests.handlebars
+++ b/templates/requests.handlebars
@@ -3,6 +3,9 @@
 {{/if ~}}
 [#{{operationIdOriginal}}-ex-request-{{@index}}]
 .{{#with summary}}{{{this}}}{{else}}Example {{@index}}{{/with}}
+{{~#with description}}
+{{{this}}}
+{{/with}}
 [source,{{language}}]
 ----
 {{#with value}}{{#if isJson}}{{#json pretty=true}}{{{this}}}{{/json}}{{else}}{{{this}}}{{/if}}{{/with}}

--- a/templates/responses.handlebars
+++ b/templates/responses.handlebars
@@ -6,6 +6,9 @@
 {{/if ~}}
 [#{{operationIdOriginal}}-ex-response-{{code}}-{{@index}}]
 .{{#with summary}}{{{this}}}{{else}}Example {{@index}}{{/with}}
+{{~#with description}}
+{{{this}}}
+{{/with}}
 [source,{{language}}]
 ----
 {{#with value}}{{#if isJson}}{{#json pretty=true}}{{{this}}}{{/json}}{{else}}{{{this}}}{{/if}}{{/with}}


### PR DESCRIPTION
Docs issue: DOC-14222

Updates the OpenAPI generator templates to include the description in request body and response examples, if present. It also includes the description in [x-codeSamples](https://redocly.com/docs/redoc/redoc-vendor-extensions#x-codesamples) objects, if present, even though `description` is not an official part of the [Code Sample Object](https://redocly.com/docs/redoc/redoc-vendor-extensions#code-sample-object) spec.